### PR TITLE
fix: add option to use transfer_from

### DIFF
--- a/backstop/src/backstop/deposit.rs
+++ b/backstop/src/backstop/deposit.rs
@@ -65,6 +65,12 @@ mod tests {
         mock_pool_factory_client.set_pool(&pool_0_id);
         mock_pool_factory_client.set_pool(&pool_1_id);
 
+        backstop_token_client.approve(
+            &frodo,
+            &backstop_address,
+            &25_0000000,
+            &e.ledger().sequence(),
+        );
         // initialize pool 0 with funds + some profit
         e.as_contract(&backstop_address, || {
             execute_deposit(&e, &frodo, &pool_0_id, 25_0000000);
@@ -234,6 +240,12 @@ mod tests {
         mock_pool_factory_client.set_pool(&pool_0_id);
         mock_pool_factory_client.set_pool(&pool_1_id);
 
+        backstop_token_client.approve(
+            &frodo,
+            &backstop_address,
+            &(10_000_000 * SCALAR_7),
+            &e.ledger().sequence(),
+        );
         // initialize pool 0 with funds + some profit
         e.as_contract(&backstop_address, || {
             execute_deposit(&e, &frodo, &pool_0_id, SCALAR_7);

--- a/backstop/src/backstop/fund_management.rs
+++ b/backstop/src/backstop/fund_management.rs
@@ -34,7 +34,12 @@ pub fn execute_donate(e: &Env, from: &Address, pool_address: &Address, amount: i
     require_is_from_pool_factory(e, pool_address, pool_balance.shares);
 
     let backstop_token = TokenClient::new(e, &storage::get_backstop_token(e));
-    backstop_token.transfer(from, &e.current_contract_address(), &amount);
+    backstop_token.transfer_from(
+        &e.current_contract_address(),
+        from,
+        &e.current_contract_address(),
+        &amount,
+    );
 
     pool_balance.deposit(amount, 0);
     storage::set_pool_balance(e, pool_address, &pool_balance);
@@ -102,6 +107,7 @@ mod tests {
             execute_deposit(&e, &frodo, &pool_0_id, 25_0000000);
         });
 
+        backstop_token_client.approve(&samwise, &backstop_id, &30_0000000, &e.ledger().sequence());
         e.as_contract(&backstop_id, || {
             execute_donate(&e, &samwise, &pool_0_id, 30_0000000);
 

--- a/backstop/src/backstop/withdrawal.rs
+++ b/backstop/src/backstop/withdrawal.rs
@@ -328,6 +328,12 @@ mod tests {
             max_entry_ttl: 3110400,
         });
 
+        backstop_token_client.approve(
+            &samwise,
+            &backstop_address,
+            &50_0000000,
+            &e.ledger().sequence(),
+        );
         // setup pool with queue for withdrawal and allow the backstop to incur a profit
         e.as_contract(&backstop_address, || {
             execute_deposit(&e, &samwise, &pool_address, 100_0000000);
@@ -395,6 +401,12 @@ mod tests {
             max_entry_ttl: 3110400,
         });
 
+        backstop_token_client.approve(
+            &samwise,
+            &backstop_address,
+            &50_0000000,
+            &e.ledger().sequence(),
+        );
         // setup pool with queue for withdrawal and allow the backstop to incur a profit
         e.as_contract(&backstop_address, || {
             execute_deposit(&e, &samwise, &pool_address, 100_0000000);

--- a/backstop/src/contract.rs
+++ b/backstop/src/contract.rs
@@ -158,7 +158,7 @@ pub trait Backstop {
     /// * `amount` - The amount of BLND to add
     ///
     /// ### Errors
-    /// If the `pool_address` is not valid, or if the pool does not
+    /// If the `pool_address` is not valid, backstop does not have sufficient allowance from `from`, or if the pool does not
     /// authorize the call
     fn donate(e: Env, from: Address, pool_address: Address, amount: i128);
 

--- a/pool/src/auctions/backstop_interest_auction.rs
+++ b/pool/src/auctions/backstop_interest_auction.rs
@@ -744,6 +744,13 @@ mod tests {
             ],
             block: 51,
         };
+
+        backstop_token_client.approve(
+            &samwise,
+            &backstop_address,
+            &75_0000000,
+            &e.ledger().sequence(),
+        );
         e.as_contract(&pool_address, || {
             e.mock_all_auths_allowing_non_root_auth();
             storage::set_auction(

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -187,8 +187,107 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #9)")]
     fn test_submit_use_allowance() {
+        let e = Env::default();
+        e.budget().reset_unlimited();
+        e.mock_all_auths_allowing_non_root_auth();
+
+        e.ledger().set(LedgerInfo {
+            timestamp: 600,
+            protocol_version: 22,
+            sequence_number: 1234,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 3110400,
+        });
+
+        let bombadil = Address::generate(&e);
+        let samwise = Address::generate(&e);
+        let frodo = Address::generate(&e);
+        let merry = Address::generate(&e);
+        let pool = testutils::create_pool(&e);
+        let (oracle, oracle_client) = testutils::create_mock_oracle(&e);
+
+        let (underlying_0, underlying_0_client) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
+        testutils::create_reserve(&e, &pool, &underlying_0, &reserve_config, &reserve_data);
+
+        let (underlying_1, underlying_1_client) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
+        testutils::create_reserve(&e, &pool, &underlying_1, &reserve_config, &reserve_data);
+
+        underlying_0_client.mint(&frodo, &16_0000000);
+
+        oracle_client.set_data(
+            &bombadil,
+            &Asset::Other(Symbol::new(&e, "USD")),
+            &vec![
+                &e,
+                Asset::Stellar(underlying_0.clone()),
+                Asset::Stellar(underlying_1.clone()),
+            ],
+            &7,
+            &300,
+        );
+        oracle_client.set_price_stable(&vec![&e, 1_0000000, 5_0000000]);
+
+        let pool_config = PoolConfig {
+            oracle,
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 2,
+        };
+        e.as_contract(&pool, || {
+            e.mock_all_auths_allowing_non_root_auth();
+            storage::set_pool_config(&e, &pool_config);
+
+            let pre_pool_balance_0 = underlying_0_client.balance(&pool);
+            let pre_pool_balance_1 = underlying_1_client.balance(&pool);
+
+            let requests = vec![
+                &e,
+                Request {
+                    request_type: RequestType::SupplyCollateral as u32,
+                    address: underlying_0,
+                    amount: 15_0000000,
+                },
+                Request {
+                    request_type: RequestType::Borrow as u32,
+                    address: underlying_1,
+                    amount: 1_5000000,
+                },
+            ];
+            underlying_0_client.approve(&frodo, &pool, &15_0000000, &e.ledger().sequence());
+            assert_eq!(underlying_0_client.allowance(&frodo, &pool), 15_0000000);
+
+            let positions = execute_submit(&e, &samwise, &frodo, &merry, requests, true);
+
+            assert_eq!(positions.liabilities.len(), 1);
+            assert_eq!(positions.collateral.len(), 1);
+            assert_eq!(positions.supply.len(), 0);
+            assert_eq!(positions.collateral.get_unchecked(0), 14_9999884);
+            assert_eq!(positions.liabilities.get_unchecked(1), 1_4999983);
+
+            assert_eq!(
+                underlying_0_client.balance(&pool),
+                pre_pool_balance_0 + 15_0000000
+            );
+            assert_eq!(underlying_1_client.allowance(&frodo, &pool), 0);
+            assert_eq!(
+                underlying_1_client.balance(&pool),
+                pre_pool_balance_1 - 1_5000000
+            );
+
+            assert_eq!(underlying_0_client.balance(&frodo), 1_0000000);
+            assert_eq!(underlying_1_client.balance(&merry), 1_5000000);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #9)")]
+    fn test_submit_use_allowance_no_allowance() {
         let e = Env::default();
         e.budget().reset_unlimited();
         e.mock_all_auths_allowing_non_root_auth();

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -17,6 +17,7 @@ use super::{
 /// * spender - The address of the user who is sending tokens to the pool
 /// * to - The address of the user who is receiving tokens from the pool
 /// * requests - A vec of requests to be processed
+/// * use_allowance - A bool indicating if transfer_from is to be used
 ///
 /// ### Panics
 /// If the request is unable to be fully executed
@@ -26,6 +27,7 @@ pub fn execute_submit(
     spender: &Address,
     to: &Address,
     requests: Vec<Request>,
+    use_allowance: bool,
 ) -> Positions {
     if from == &e.current_contract_address()
         || spender == &e.current_contract_address()
@@ -36,7 +38,7 @@ pub fn execute_submit(
     let mut pool = Pool::load(e);
 
     let (actions, new_from_state, check_health) =
-        build_actions_from_request(e, &mut pool, from, requests);
+        build_actions_from_request(e, &mut pool, from, requests, use_allowance);
 
     // panics if the new positions set does not meet the health factor requirement
     // min is 1.0000100 to prevent rounding errors
@@ -50,7 +52,17 @@ pub fn execute_submit(
 
     // transfer tokens from sender to pool
     for (address, amount) in actions.spender_transfer.iter() {
-        TokenClient::new(e, &address).transfer(spender, &e.current_contract_address(), &amount);
+        let token = TokenClient::new(e, &address);
+        if use_allowance {
+            token.transfer_from(
+                &e.current_contract_address(),
+                spender,
+                &e.current_contract_address(),
+                &amount,
+            );
+        } else {
+            token.transfer(spender, &e.current_contract_address(), &amount);
+        }
     }
 
     // store updated info to ledger
@@ -152,7 +164,7 @@ mod tests {
                     amount: 1_5000000,
                 },
             ];
-            let positions = execute_submit(&e, &samwise, &frodo, &merry, requests);
+            let positions = execute_submit(&e, &samwise, &frodo, &merry, requests, false);
 
             assert_eq!(positions.liabilities.len(), 1);
             assert_eq!(positions.collateral.len(), 1);
@@ -174,6 +186,81 @@ mod tests {
         });
     }
 
+    #[test]
+    #[should_panic(expected = "Error(Contract, #9)")]
+    fn test_submit_use_allowance() {
+        let e = Env::default();
+        e.budget().reset_unlimited();
+        e.mock_all_auths_allowing_non_root_auth();
+
+        e.ledger().set(LedgerInfo {
+            timestamp: 600,
+            protocol_version: 22,
+            sequence_number: 1234,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 3110400,
+        });
+
+        let bombadil = Address::generate(&e);
+        let samwise = Address::generate(&e);
+        let frodo = Address::generate(&e);
+        let merry = Address::generate(&e);
+        let pool = testutils::create_pool(&e);
+        let (oracle, oracle_client) = testutils::create_mock_oracle(&e);
+
+        let (underlying_0, underlying_0_client) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
+        testutils::create_reserve(&e, &pool, &underlying_0, &reserve_config, &reserve_data);
+
+        let (underlying_1, _) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
+        testutils::create_reserve(&e, &pool, &underlying_1, &reserve_config, &reserve_data);
+
+        underlying_0_client.mint(&frodo, &16_0000000);
+
+        oracle_client.set_data(
+            &bombadil,
+            &Asset::Other(Symbol::new(&e, "USD")),
+            &vec![
+                &e,
+                Asset::Stellar(underlying_0.clone()),
+                Asset::Stellar(underlying_1.clone()),
+            ],
+            &7,
+            &300,
+        );
+        oracle_client.set_price_stable(&vec![&e, 1_0000000, 5_0000000]);
+
+        let pool_config = PoolConfig {
+            oracle,
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 2,
+        };
+
+        e.as_contract(&pool, || {
+            e.mock_all_auths_allowing_non_root_auth();
+            storage::set_pool_config(&e, &pool_config);
+            let requests = vec![
+                &e,
+                Request {
+                    request_type: RequestType::SupplyCollateral as u32,
+                    address: underlying_0,
+                    amount: 15_0000000,
+                },
+                Request {
+                    request_type: RequestType::Borrow as u32,
+                    address: underlying_1,
+                    amount: 1_5000000,
+                },
+            ];
+
+            execute_submit(&e, &samwise, &frodo, &merry, requests, true);
+        });
+    }
     #[test]
     fn test_submit_no_liabilities_does_not_load_oracle() {
         let e = Env::default();
@@ -240,7 +327,7 @@ mod tests {
                     amount: 1_5000001,
                 },
             ];
-            let positions = execute_submit(&e, &samwise, &frodo, &frodo, requests);
+            let positions = execute_submit(&e, &samwise, &frodo, &frodo, requests, false);
 
             assert_eq!(positions.liabilities.len(), 0);
             assert_eq!(positions.collateral.len(), 1);
@@ -329,7 +416,7 @@ mod tests {
                     amount: 1_7500000,
                 },
             ];
-            execute_submit(&e, &samwise, &frodo, &merry, requests);
+            execute_submit(&e, &samwise, &frodo, &merry, requests, false);
         });
     }
 
@@ -389,7 +476,7 @@ mod tests {
                     amount: 15_0000000,
                 },
             ];
-            execute_submit(&e, &pool, &samwise, &samwise, requests);
+            execute_submit(&e, &pool, &samwise, &samwise, requests, false);
         });
     }
 
@@ -449,7 +536,7 @@ mod tests {
                     amount: 15_0000000,
                 },
             ];
-            execute_submit(&e, &samwise, &pool, &samwise, requests);
+            execute_submit(&e, &samwise, &pool, &samwise, requests, false);
         });
     }
 
@@ -509,7 +596,7 @@ mod tests {
                     amount: 15_0000000,
                 },
             ];
-            execute_submit(&e, &samwise, &samwise, &pool, requests);
+            execute_submit(&e, &samwise, &samwise, &pool, requests, false);
         });
     }
 }

--- a/test-suites/tests/test_backstop.rs
+++ b/test-suites/tests/test_backstop.rs
@@ -139,6 +139,12 @@ fn test_backstop() {
     // @dev: setup jumps 1 hour and 1 minute
     fixture.jump(60 * 60 * 24 * 7 - 60 * 60);
     let amount = 2_000 * SCALAR_7;
+    fixture.lp.approve(
+        &frodo,
+        &fixture.backstop.address,
+        &amount,
+        &fixture.env.ledger().sequence(),
+    );
     fixture.backstop.donate(&frodo, &pool.address, &amount);
     frodo_bstop_token_balance -= amount;
     bstop_bstop_token_balance += amount;
@@ -157,19 +163,7 @@ fn test_backstop() {
                         amount.into_val(&fixture.env)
                     ]
                 )),
-                sub_invocations: std::vec![AuthorizedInvocation {
-                    function: AuthorizedFunction::Contract((
-                        bstop_token.address.clone(),
-                        Symbol::new(&fixture.env, "transfer"),
-                        vec![
-                            &fixture.env,
-                            frodo.to_val(),
-                            fixture.backstop.address.to_val(),
-                            amount.into_val(&fixture.env)
-                        ]
-                    )),
-                    sub_invocations: std::vec![]
-                }]
+                sub_invocations: std::vec![]
             }
         )
     );

--- a/test-suites/tests/test_backstop_inflation_attack.rs
+++ b/test-suites/tests/test_backstop_inflation_attack.rs
@@ -58,6 +58,12 @@ fn test_backstop_inflation_attack() {
     // 2b. Attacker tries to donate a large amount to the backstop before the victim can perform a deposit
     //    #! NOTE - Contract will stop a random address from donating. This can ONLY come from the pool.
     //              However, authorizations are mocked during intergation tests, so this will succeed.
+    fixture.lp.approve(
+        &sauron,
+        &fixture.backstop.address,
+        &inflation_amount,
+        &fixture.env.ledger().sequence(),
+    );
     fixture
         .backstop
         .donate(&sauron, &pool_address, &inflation_amount);

--- a/test-suites/tests/test_liquidation.rs
+++ b/test-suites/tests/test_liquidation.rs
@@ -293,6 +293,12 @@ fn test_liquidations() {
     let frodo_stable_balance = fixture.tokens[TokenIndex::STABLE].balance(&frodo);
     let frodo_xlm_balance = fixture.tokens[TokenIndex::XLM].balance(&frodo);
     let frodo_weth_balance = fixture.tokens[TokenIndex::WETH].balance(&frodo);
+    fixture.lp.approve(
+        &frodo,
+        &fixture.backstop.address,
+        &lp_donate_bid_amount,
+        &fixture.env.ledger().sequence(),
+    );
     let frodo_positions_post_fill =
         pool_fixture
             .pool


### PR DESCRIPTION
- This PR addresses issue #5
- Implemented contract function `submit_with_allowance` that implements transfers from the user to pool using transfer_from
- Replaced the `transfer` function call on the Backstop's `donate` function to `transfer_from`
