### PR TITLE
Redundant Transfers

### DIFF
--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -38,7 +38,7 @@ pub fn execute_submit(
     let mut pool = Pool::load(e);
 
     let (actions, new_from_state, check_health) =
-        build_actions_from_request(e, &mut pool, from, requests, use_allowance);
+        build_actions_from_request(e, &mut pool, from, requests);
 
     // panics if the new positions set does not meet the health factor requirement
     // min is 1.0000100 to prevent rounding errors


### PR DESCRIPTION
This PR tries to fix #4 by handling differently transfers with and without allowance. When executing transfers with allowance, the amounts are netted and only one transfer per asset is done.

As a side effect, no need to further pass `use_allowance` param to `build_actions_with_request()` and use it only in repay which was doing the same work as the parent now. So this param was removed and the dedicated tests cut off. 