### PR TITLE
Backstop emissions refactor

### DIFF
--- a/backstop/src/backstop/deposit.rs
+++ b/backstop/src/backstop/deposit.rs
@@ -15,6 +15,9 @@ pub fn execute_deposit(e: &Env, from: &Address, pool_address: &Address, amount: 
     let mut user_balance = storage::get_user_balance(e, pool_address, from);
 
     emissions::update_emissions(e, pool_address, &pool_balance, from, &user_balance);
+    if storage::get_backstop_gulp_index(e, &pool_address).is_some() {
+        emissions::gulp_emissions(e, pool_address);
+    }
 
     let backstop_token_client = TokenClient::new(e, &storage::get_backstop_token(e));
     backstop_token_client.transfer(from, &e.current_contract_address(), &amount);

--- a/backstop/src/backstop/deposit.rs
+++ b/backstop/src/backstop/deposit.rs
@@ -15,9 +15,6 @@ pub fn execute_deposit(e: &Env, from: &Address, pool_address: &Address, amount: 
     let mut user_balance = storage::get_user_balance(e, pool_address, from);
 
     emissions::update_emissions(e, pool_address, &pool_balance, from, &user_balance);
-    if storage::get_backstop_gulp_index(e, &pool_address).is_some() {
-        emissions::gulp_emissions(e, pool_address);
-    }
 
     let backstop_token_client = TokenClient::new(e, &storage::get_backstop_token(e));
     backstop_token_client.transfer(from, &e.current_contract_address(), &amount);

--- a/backstop/src/backstop/withdrawal.rs
+++ b/backstop/src/backstop/withdrawal.rs
@@ -18,9 +18,7 @@ pub fn execute_queue_withdrawal(
 
     // update emissions
     emissions::update_emissions(e, pool_address, &pool_balance, from, &user_balance);
-    if storage::get_backstop_gulp_index(e, &pool_address).is_some() {
-        emissions::gulp_emissions(e, pool_address);
-    }
+
     user_balance.queue_shares_for_withdrawal(e, amount);
     pool_balance.queue_for_withdraw(amount);
 
@@ -39,9 +37,7 @@ pub fn execute_dequeue_withdrawal(e: &Env, from: &Address, pool_address: &Addres
 
     // update emissions
     emissions::update_emissions(e, pool_address, &pool_balance, from, &user_balance);
-    if storage::get_backstop_gulp_index(e, &pool_address).is_some() {
-        emissions::gulp_emissions(e, pool_address);
-    }
+
     user_balance.dequeue_shares_for_withdrawal(e, amount, false);
     user_balance.add_shares(amount);
     pool_balance.dequeue_q4w(e, amount);

--- a/backstop/src/backstop/withdrawal.rs
+++ b/backstop/src/backstop/withdrawal.rs
@@ -18,7 +18,9 @@ pub fn execute_queue_withdrawal(
 
     // update emissions
     emissions::update_emissions(e, pool_address, &pool_balance, from, &user_balance);
-
+    if storage::get_backstop_gulp_index(e, &pool_address).is_some() {
+        emissions::gulp_emissions(e, pool_address);
+    }
     user_balance.queue_shares_for_withdrawal(e, amount);
     pool_balance.queue_for_withdraw(amount);
 
@@ -37,7 +39,9 @@ pub fn execute_dequeue_withdrawal(e: &Env, from: &Address, pool_address: &Addres
 
     // update emissions
     emissions::update_emissions(e, pool_address, &pool_balance, from, &user_balance);
-
+    if storage::get_backstop_gulp_index(e, &pool_address).is_some() {
+        emissions::gulp_emissions(e, pool_address);
+    }
     user_balance.dequeue_shares_for_withdrawal(e, amount, false);
     user_balance.add_shares(amount);
     pool_balance.dequeue_q4w(e, amount);

--- a/backstop/src/constants.rs
+++ b/backstop/src/constants.rs
@@ -4,10 +4,8 @@ pub const SCALAR_7: i128 = 1_0000000;
 /// Fixed-point scalar for 14 decimal numbers
 pub const SCALAR_14: i128 = 1_0000000_0000000;
 
-/// The approximate deployment time in seconds since epoch of the backstop module. This is NOT the
-/// actual deployment time and should not be considered accruate. It is only used to determine reward
-/// zone size on ~90 day intervals, starting at 10 on or before April 15th, 2024 00:00:00 UTC.
-pub const BACKSTOP_EPOCH: u64 = 1713139200;
+/// The maximum reward zone size
+pub const MAX_RZ_SIZE: u32 = 50;
 
 /// The maximum amount of active Q4W entries that a user can have against a single backstop.
 /// Set such that a user can create a maximum of 1 entry per day over the 21 day lock period.

--- a/backstop/src/constants.rs
+++ b/backstop/src/constants.rs
@@ -1,6 +1,9 @@
 /// Fixed-point scalar for 7 decimal numbers
 pub const SCALAR_7: i128 = 1_0000000;
 
+/// Fixed-point scalar for 14 decimal numbers
+pub const SCALAR_14: i128 = 1_0000000_0000000;
+
 /// The approximate deployment time in seconds since epoch of the backstop module. This is NOT the
 /// actual deployment time and should not be considered accruate. It is only used to determine reward
 /// zone size on ~90 day intervals, starting at 10 on or before April 15th, 2024 00:00:00 UTC.

--- a/backstop/src/contract.rs
+++ b/backstop/src/contract.rs
@@ -100,21 +100,31 @@ pub trait Backstop {
 
     /********** Emissions **********/
 
-    /// Consume emissions from the Emitter and distribute them to backstops and pools in the reward zone
-    fn gulp_emissions(e: Env);
+    /// Update the backstop with new emissions for all reward zone pools
+    ///
+    /// Returns the amount of new emissions for all reward zone pools
+    fn distribute(e: Env) -> i128;
+
+    /// Distribute emissions to a reward zone pool and its backstop
+    ///
+    /// Returns the amount of BLND emissions distributed to the pool
+    ///
+    /// ### Arguments
+    /// * `pool` - The address of the pool to distribute emissions to
+    ///
+    /// ### Errors
+    /// If the pool is not in the reward zone or the pool does not authorize the call
+    fn gulp_emissions(e: Env, pool: Address) -> i128;
 
     /// Add a pool to the reward zone, and if the reward zone is full, a pool to remove
     ///
     /// ### Arguments
     /// * `to_add` - The address of the pool to add
-    /// * `to_remove` - The address of the pool to remove
+    /// * `to_remove` - The address of the pool to remove (Optional - Used if the reward zone is full)
     ///
     /// ### Errors
     /// If the pool to remove has more tokens, or if distribution occurred in the last 48 hours
-    fn add_reward(e: Env, to_add: Address, to_remove: Address);
-
-    /// Consume the emissions for a pool and approve
-    fn gulp_pool_emissions(e: Env, pool_address: Address) -> i128;
+    fn add_reward(e: Env, to_add: Address, to_remove: Option<Address>);
 
     /// Claim backstop deposit emissions from a list of pools for `from`
     ///
@@ -264,24 +274,28 @@ impl Backstop for BackstopContract {
 
     /********** Emissions **********/
 
-    fn gulp_emissions(e: Env) {
+    fn distribute(e: Env) -> i128 {
         storage::extend_instance(&e);
-        let new_tokens_emitted = emissions::gulp_emissions(&e);
+        let new_emissions = emissions::distribute(&e);
 
-        BackstopEvents::gulp_emissions(&e, new_tokens_emitted);
+        BackstopEvents::distribute(&e, new_emissions);
+        new_emissions
     }
 
-    fn add_reward(e: Env, to_add: Address, to_remove: Address) {
+    fn gulp_emissions(e: Env, pool: Address) -> i128 {
+        storage::extend_instance(&e);
+        pool.require_auth();
+        let (backstop_emissions, pool_emissions) = emissions::gulp_emissions(&e, &pool);
+
+        BackstopEvents::gulp_emissions(&e, pool, backstop_emissions, pool_emissions);
+        pool_emissions
+    }
+
+    fn add_reward(e: Env, to_add: Address, to_remove: Option<Address>) {
         storage::extend_instance(&e);
         emissions::add_to_reward_zone(&e, to_add.clone(), to_remove.clone());
 
         BackstopEvents::rw_zone(&e, to_add, to_remove);
-    }
-
-    fn gulp_pool_emissions(e: Env, pool_address: Address) -> i128 {
-        storage::extend_instance(&e);
-        pool_address.require_auth();
-        emissions::gulp_pool_emissions(&e, &pool_address)
     }
 
     fn claim(e: Env, from: Address, pool_addresses: Vec<Address>, to: Address) -> i128 {

--- a/backstop/src/contract.rs
+++ b/backstop/src/contract.rs
@@ -126,6 +126,15 @@ pub trait Backstop {
     /// If the pool to remove has more tokens, or if distribution occurred in the last 48 hours
     fn add_reward(e: Env, to_add: Address, to_remove: Option<Address>);
 
+    /// Remove a pool from the reward zone
+    ///
+    /// ### Arguments
+    /// * `to_remove` - The address of the pool to remove
+    ///
+    /// ### Errors
+    /// If the pool is not below the threshold or if the pool is not in the reward zone
+    fn remove_reward(e: Env, to_remove: Address);
+
     /// Claim backstop deposit emissions from a list of pools for `from`
     ///
     /// Returns the amount of BLND emissions claimed
@@ -295,7 +304,14 @@ impl Backstop for BackstopContract {
         storage::extend_instance(&e);
         emissions::add_to_reward_zone(&e, to_add.clone(), to_remove.clone());
 
-        BackstopEvents::rw_zone(&e, to_add, to_remove);
+        BackstopEvents::rw_zone_add(&e, to_add, to_remove);
+    }
+
+    fn remove_reward(e: Env, to_remove: Address) {
+        storage::extend_instance(&e);
+        emissions::remove_from_reward_zone(&e, to_remove.clone());
+
+        BackstopEvents::rw_zone_remove(&e, to_remove);
     }
 
     fn claim(e: Env, from: Address, pool_addresses: Vec<Address>, to: Address) -> i128 {

--- a/backstop/src/emissions/claim.rs
+++ b/backstop/src/emissions/claim.rs
@@ -90,6 +90,7 @@ mod tests {
         unwrap::UnwrapOptimized,
         vec,
     };
+    use storage::RzEmissionData;
 
     /********** claim **********/
 
@@ -151,7 +152,23 @@ mod tests {
             storage::set_user_emis_data(&e, &pool_2_id, &samwise, &user_2_emissions_data);
             storage::set_backstop_token(&e, &lp_address);
             storage::set_blnd_token(&e, &blnd_address);
-
+            storage::set_rz_emission_index(&e, &1_00000000000000);
+            storage::set_rz_emis_data(
+                &e,
+                &pool_1_id,
+                &RzEmissionData {
+                    index: 0,
+                    accrued: 0,
+                },
+            );
+            storage::set_rz_emis_data(
+                &e,
+                &pool_2_id,
+                &RzEmissionData {
+                    index: 0,
+                    accrued: 0,
+                },
+            );
             storage::set_pool_balance(
                 &e,
                 &pool_1_id,
@@ -244,6 +261,15 @@ mod tests {
             assert_eq!(new_backstop_2_data.index, 70526315789473);
             assert_eq!(new_user_2_data.accrued, 0);
             assert_eq!(new_user_2_data.index, 70526315789473);
+
+            let new_rz_emission_1_data =
+                storage::get_rz_emis_data(&e, &pool_1_id).unwrap_optimized();
+            assert_eq!(new_rz_emission_1_data.index, 100000000000000);
+            assert_eq!(new_rz_emission_1_data.accrued, 1973333334);
+            let new_rz_emission_2_data =
+                storage::get_rz_emis_data(&e, &pool_2_id).unwrap_optimized();
+            assert_eq!(new_rz_emission_2_data.index, 100000000000000);
+            assert_eq!(new_rz_emission_2_data.accrued, 712500000);
         });
     }
 

--- a/backstop/src/emissions/claim.rs
+++ b/backstop/src/emissions/claim.rs
@@ -123,18 +123,18 @@ mod tests {
 
         let backstop_1_emissions_data = BackstopEmissionData {
             expiration: 1500000000 + 7 * 24 * 60 * 60,
-            eps: 0_1000000,
-            index: 22222,
+            eps: 0_10000000000000,
+            index: 222220000000,
             last_time: 1500000000,
         };
         let user_1_emissions_data = UserEmissionData {
-            index: 11111,
+            index: 111110000000,
             accrued: 1_2345678,
         };
 
         let backstop_2_emissions_data = BackstopEmissionData {
             expiration: 1500000000 + 7 * 24 * 60 * 60,
-            eps: 0_0200000,
+            eps: 0_02000000000000,
             index: 0,
             last_time: 1500010000,
         };
@@ -202,27 +202,27 @@ mod tests {
                 &vec![&e, pool_1_id.clone(), pool_2_id.clone()],
                 &frodo,
             );
-            assert_eq!(result, 75_3145677 + 6_2904190);
+            assert_eq!(result, 76_3155136 + 5_2894736);
             assert_eq!(
                 lp_client.balance(&backstop_address),
-                backstop_lp_balance + 6_4729326
+                backstop_lp_balance + 6_4729327
             );
             assert_eq!(
                 blnd_token_client.balance(&backstop_address),
-                100_0000000 - (75_3145677 + 6_2904190)
+                100_0000000 - (76_3155136 + 5_2894736)
             );
             let sam_balance_1 = storage::get_user_balance(&e, &pool_1_id, &samwise);
             assert_eq!(sam_balance_1.shares, 9_0000000);
             let frodo_balance_1 = storage::get_user_balance(&e, &pool_1_id, &frodo);
-            assert_eq!(frodo_balance_1.shares, pre_frodo_balance_1 + 4_5400274);
+            assert_eq!(frodo_balance_1.shares, pre_frodo_balance_1 + 4_5400275);
             let sam_balance_2 = storage::get_user_balance(&e, &pool_2_id, &samwise);
             assert_eq!(sam_balance_2.shares, 7_5000000);
             let frodo_balance_2 = storage::get_user_balance(&e, &pool_2_id, &frodo);
             assert_eq!(frodo_balance_2.shares, pre_frodo_balance_2 + 0_3915917);
 
             let pool_balance_1 = storage::get_pool_balance(&e, &pool_1_id);
-            assert_eq!(pool_balance_1.tokens, pre_pool_tokens_1 + 6_0533699);
-            assert_eq!(pool_balance_1.shares, pre_pool_shares_1 + 4_5400274);
+            assert_eq!(pool_balance_1.tokens, pre_pool_tokens_1 + 6_0533700);
+            assert_eq!(pool_balance_1.shares, pre_pool_shares_1 + 4_5400275);
             let pool_balance_2 = storage::get_pool_balance(&e, &pool_2_id);
             assert_eq!(pool_balance_2.tokens, pre_pool_tokens_2 + 0_4195626);
             assert_eq!(pool_balance_2.shares, pre_pool_shares_2 + 0_3915917);
@@ -232,18 +232,18 @@ mod tests {
             let new_user_1_data =
                 storage::get_user_emis_data(&e, &pool_1_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_1_data.last_time, block_timestamp);
-            assert_eq!(new_backstop_1_data.index, 83434384);
+            assert_eq!(new_backstop_1_data.index, 834343841621621);
             assert_eq!(new_user_1_data.accrued, 0);
-            assert_eq!(new_user_1_data.index, 83434384);
+            assert_eq!(new_user_1_data.index, 834343841621621);
 
             let new_backstop_2_data =
                 storage::get_backstop_emis_data(&e, &pool_2_id).unwrap_optimized();
             let new_user_2_data =
                 storage::get_user_emis_data(&e, &pool_2_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_2_data.last_time, block_timestamp);
-            assert_eq!(new_backstop_2_data.index, 7052631);
+            assert_eq!(new_backstop_2_data.index, 70526315789473);
             assert_eq!(new_user_2_data.accrued, 0);
-            assert_eq!(new_user_2_data.index, 7052631);
+            assert_eq!(new_user_2_data.index, 70526315789473);
         });
     }
 
@@ -278,18 +278,18 @@ mod tests {
 
         let backstop_1_emissions_data = BackstopEmissionData {
             expiration: 1500000000 + 7 * 24 * 60 * 60,
-            eps: 0_1000000,
-            index: 22222,
+            eps: 0_10000000000000,
+            index: 222220000000,
             last_time: 1500000000,
         };
         let user_1_emissions_data = UserEmissionData {
-            index: 11111,
+            index: 111110000000,
             accrued: 1_2345678,
         };
 
         let backstop_2_emissions_data = BackstopEmissionData {
             expiration: 1500000000 + 7 * 24 * 60 * 60,
-            eps: 0_0200000,
+            eps: 0_02000000000000,
             index: 0,
             last_time: 1500010000,
         };
@@ -355,27 +355,27 @@ mod tests {
                 &vec![&e, pool_1_id.clone(), pool_2_id.clone()],
                 &frodo,
             );
-            assert_eq!(result, 75_3145677 + 6_2904190);
+            assert_eq!(result, 76_3155136 + 5_2894736);
             assert_eq!(
                 lp_client.balance(&backstop_address),
-                backstop_lp_balance + 6_4729326
+                backstop_lp_balance + 6_4729327
             );
             assert_eq!(
                 blnd_token_client.balance(&backstop_address),
-                200_0000000 - (75_3145677 + 6_2904190)
+                200_0000000 - (76_3155136 + 5_2894736)
             );
             let sam_balance_1 = storage::get_user_balance(&e, &pool_1_id, &samwise);
             assert_eq!(sam_balance_1.shares, 9_0000000);
             let frodo_balance_1 = storage::get_user_balance(&e, &pool_1_id, &frodo);
-            assert_eq!(frodo_balance_1.shares, pre_frodo_balance_1 + 4_5400274);
+            assert_eq!(frodo_balance_1.shares, pre_frodo_balance_1 + 4_5400275);
             let sam_balance_2 = storage::get_user_balance(&e, &pool_2_id, &samwise);
             assert_eq!(sam_balance_2.shares, 7_5000000);
             let frodo_balance_2 = storage::get_user_balance(&e, &pool_2_id, &frodo);
             assert_eq!(frodo_balance_2.shares, pre_frodo_balance_2 + 0_3915917);
 
             let pool_balance_1 = storage::get_pool_balance(&e, &pool_1_id);
-            assert_eq!(pool_balance_1.tokens, pre_pool_tokens_1 + 6_0533699);
-            assert_eq!(pool_balance_1.shares, pre_pool_shares_1 + 4_5400274);
+            assert_eq!(pool_balance_1.tokens, pre_pool_tokens_1 + 6_0533700);
+            assert_eq!(pool_balance_1.shares, pre_pool_shares_1 + 4_5400275);
             let pool_balance_2 = storage::get_pool_balance(&e, &pool_2_id);
             assert_eq!(pool_balance_2.tokens, pre_pool_tokens_2 + 0_4195626);
             assert_eq!(pool_balance_2.shares, pre_pool_shares_2 + 0_3915917);
@@ -385,18 +385,18 @@ mod tests {
             let new_user_1_data =
                 storage::get_user_emis_data(&e, &pool_1_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_1_data.last_time, block_timestamp);
-            assert_eq!(new_backstop_1_data.index, 83434384);
+            assert_eq!(new_backstop_1_data.index, 834343841621621);
             assert_eq!(new_user_1_data.accrued, 0);
-            assert_eq!(new_user_1_data.index, 83434384);
+            assert_eq!(new_user_1_data.index, 834343841621621);
 
             let new_backstop_2_data =
                 storage::get_backstop_emis_data(&e, &pool_2_id).unwrap_optimized();
             let new_user_2_data =
                 storage::get_user_emis_data(&e, &pool_2_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_2_data.last_time, block_timestamp);
-            assert_eq!(new_backstop_2_data.index, 7052631);
+            assert_eq!(new_backstop_2_data.index, 70526315789473);
             assert_eq!(new_user_2_data.accrued, 0);
-            assert_eq!(new_user_2_data.index, 7052631);
+            assert_eq!(new_user_2_data.index, 70526315789473);
 
             let block_timestamp_1 = 1500000000 + 12345 + 12345;
             e.ledger().set(LedgerInfo {
@@ -422,47 +422,47 @@ mod tests {
                 &vec![&e, pool_1_id.clone(), pool_2_id.clone()],
                 &frodo,
             );
-            assert_eq!(result_1, 1005194703);
+            assert_eq!(result_1, 1005194713);
             assert_eq!(
                 blnd_token_client.balance(&backstop_address),
-                200_0000000 - (75_3145677 + 6_2904190) - (1005194703)
+                200_0000000 - (76_3155136 + 5_2894736) - (1005194713)
             );
             assert_eq!(
                 lp_client.balance(&backstop_address),
-                backstop_lp_balance + 7_7889107
+                backstop_lp_balance + 7_7889109
             );
             let sam_balance_1 = storage::get_user_balance(&e, &pool_1_id, &samwise);
             assert_eq!(sam_balance_1.shares, 9_0000000);
             let frodo_balance_1 = storage::get_user_balance(&e, &pool_1_id, &frodo);
-            assert_eq!(frodo_balance_1.shares, pre_frodo_balance_1 + 4_2609092);
+            assert_eq!(frodo_balance_1.shares, pre_frodo_balance_1 + 4_2609093);
             let sam_balance_2 = storage::get_user_balance(&e, &pool_2_id, &samwise);
             assert_eq!(sam_balance_2.shares, 7_5000000);
             let frodo_balance_2 = storage::get_user_balance(&e, &pool_2_id, &frodo);
-            assert_eq!(frodo_balance_2.shares, pre_frodo_balance_2 + 2_0152958);
+            assert_eq!(frodo_balance_2.shares, pre_frodo_balance_2 + 2_0152959);
 
             let pool_balance_1 = storage::get_pool_balance(&e, &pool_1_id);
             assert_eq!(pool_balance_1.tokens, pre_pool_tokens_1 + 5_6812124);
-            assert_eq!(pool_balance_1.shares, pre_pool_shares_1 + 4_2609092);
+            assert_eq!(pool_balance_1.shares, pre_pool_shares_1 + 4_2609093);
             let pool_balance_2 = storage::get_pool_balance(&e, &pool_2_id);
-            assert_eq!(pool_balance_2.tokens, pre_pool_tokens_2 + 2_1592456);
-            assert_eq!(pool_balance_2.shares, pre_pool_shares_2 + 2_0152958);
+            assert_eq!(pool_balance_2.tokens, pre_pool_tokens_2 + 2_1592457);
+            assert_eq!(pool_balance_2.shares, pre_pool_shares_2 + 2_0152959);
             let new_backstop_1_data =
                 storage::get_backstop_emis_data(&e, &pool_1_id).unwrap_optimized();
             let new_user_1_data =
                 storage::get_user_emis_data(&e, &pool_1_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_1_data.last_time, block_timestamp_1);
-            assert_eq!(new_backstop_1_data.index, 164363961);
+            assert_eq!(new_backstop_1_data.index, 1643639618102322);
             assert_eq!(new_user_1_data.accrued, 0);
-            assert_eq!(new_user_1_data.index, 164363961);
+            assert_eq!(new_user_1_data.index, 1643639618102322);
 
             let new_backstop_2_data =
                 storage::get_backstop_emis_data(&e, &pool_2_id).unwrap_optimized();
             let new_user_2_data =
                 storage::get_user_emis_data(&e, &pool_2_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_2_data.last_time, block_timestamp_1);
-            assert_eq!(new_backstop_2_data.index, 43963099);
+            assert_eq!(new_backstop_2_data.index, 439631002529944);
             assert_eq!(new_user_2_data.accrued, 0);
-            assert_eq!(new_user_2_data.index, 43963099);
+            assert_eq!(new_user_2_data.index, 439631002529944);
         });
     }
 
@@ -494,14 +494,14 @@ mod tests {
 
         let backstop_1_emissions_data = BackstopEmissionData {
             expiration: 1500000000 + 7 * 24 * 60 * 60,
-            eps: 0_1000000,
-            index: 22222,
+            eps: 0_10000000000000,
+            index: 222220000000,
             last_time: 1500000000,
         };
 
         let backstop_2_emissions_data = BackstopEmissionData {
             expiration: 1500000000 + 7 * 24 * 60 * 60,
-            eps: 0_0200000,
+            eps: 0_02000000000000,
             index: 0,
             last_time: 1500010000,
         };
@@ -543,18 +543,18 @@ mod tests {
             let new_user_1_data =
                 storage::get_user_emis_data(&e, &pool_1_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_1_data.last_time, block_timestamp);
-            assert_eq!(new_backstop_1_data.index, 82322222);
+            assert_eq!(new_backstop_1_data.index, 823222220000000);
             assert_eq!(new_user_1_data.accrued, 0);
-            assert_eq!(new_user_1_data.index, 82322222);
+            assert_eq!(new_user_1_data.index, 823222220000000);
 
             let new_backstop_2_data =
                 storage::get_backstop_emis_data(&e, &pool_2_id).unwrap_optimized();
             let new_user_2_data =
                 storage::get_user_emis_data(&e, &pool_2_id, &samwise).unwrap_optimized();
             assert_eq!(new_backstop_2_data.last_time, block_timestamp);
-            assert_eq!(new_backstop_2_data.index, 6700000);
+            assert_eq!(new_backstop_2_data.index, 67000000000000);
             assert_eq!(new_user_2_data.accrued, 0);
-            assert_eq!(new_user_2_data.index, 6700000);
+            assert_eq!(new_user_2_data.index, 67000000000000);
         });
     }
 }

--- a/backstop/src/emissions/distributor.rs
+++ b/backstop/src/emissions/distributor.rs
@@ -151,7 +151,7 @@ fn set_user_emissions(
 
 #[cfg(test)]
 mod tests {
-    use crate::{constants::BACKSTOP_EPOCH, testutils::create_backstop, Q4W};
+    use crate::{testutils::create_backstop, Q4W};
 
     use super::*;
     use soroban_sdk::{
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn test_update_emissions() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -182,17 +182,17 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_10000000000000,
             index: 222220000000,
-            last_time: BACKSTOP_EPOCH,
+            last_time: 1713139200,
         };
         let user_emissions_data = UserEmissionData {
             index: 111110000000,
             accrued: 3,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
             storage::set_user_emis_data(&e, &pool_1, &samwise, &user_emissions_data);
             storage::set_rz_emission_index(&e, &1_00000000000000);
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn test_update_emissions_no_data() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -252,7 +252,7 @@ mod tests {
         let samwise = Address::generate(&e);
 
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             let pool_balance = PoolBalance {
                 shares: 150_0000000,
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn test_update_emissions_first_action() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 12345;
+        let block_timestamp = 1713139200 + 12345;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -293,13 +293,13 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_04200000000000,
             index: 222220000000,
-            last_time: BACKSTOP_EPOCH,
+            last_time: 1713139200,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
 
@@ -328,7 +328,7 @@ mod tests {
     #[test]
     fn test_update_emissions_config_set_after_user() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 12345;
+        let block_timestamp = 1713139200 + 12345;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -345,13 +345,13 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_04200000000000,
             index: 0,
-            last_time: BACKSTOP_EPOCH,
+            last_time: 1713139200,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
 
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn test_update_emissions_q4w_not_counted() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -397,17 +397,17 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_10000000000000,
             index: 222220000000,
-            last_time: BACKSTOP_EPOCH,
+            last_time: 1713139200,
         };
         let user_emissions_data = UserEmissionData {
             index: 111110000000,
             accrued: 3,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
             storage::set_user_emis_data(&e, &pool_1, &samwise, &user_emissions_data);
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn test_claim_emissions() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -458,17 +458,17 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_10000000000000,
             index: 222220000000,
-            last_time: BACKSTOP_EPOCH,
+            last_time: 1713139200,
         };
         let user_emissions_data = UserEmissionData {
             index: 111110000000,
             accrued: 3,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
             storage::set_user_emis_data(&e, &pool_1, &samwise, &user_emissions_data);
@@ -513,7 +513,7 @@ mod tests {
     #[test]
     fn test_claim_emissions_no_config() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -530,7 +530,7 @@ mod tests {
         let samwise = Address::generate(&e);
 
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             let pool_balance = PoolBalance {
                 shares: 150_0000000,
@@ -559,7 +559,7 @@ mod tests {
     #[should_panic(expected = "Error(Contract, #8)")]
     fn test_update_emissions_more_q4w_than_shares_panics() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -576,17 +576,17 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_10000000000000,
             index: 22222,
-            last_time: BACKSTOP_EPOCH,
+            last_time: 1713139200,
         };
         let user_emissions_data = UserEmissionData {
             index: 11111,
             accrued: 3,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
             storage::set_user_emis_data(&e, &pool_1, &samwise, &user_emissions_data);
@@ -613,7 +613,7 @@ mod tests {
     #[should_panic(expected = "attempt to subtract with overflow")]
     fn test_update_emissions_negative_time_dif() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -630,7 +630,7 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_10000000000000,
             index: 22222,
             last_time: block_timestamp + 1,
@@ -640,7 +640,7 @@ mod tests {
             accrued: 3,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
             storage::set_user_emis_data(&e, &pool_1, &samwise, &user_emissions_data);
@@ -663,7 +663,7 @@ mod tests {
     #[should_panic(expected = "Error(Contract, #8)")]
     fn test_update_emissions_negative_user_index() {
         let e = Env::default();
-        let block_timestamp = BACKSTOP_EPOCH + 1234;
+        let block_timestamp = 1713139200 + 1234;
         e.ledger().set(LedgerInfo {
             timestamp: block_timestamp,
             protocol_version: 22,
@@ -680,17 +680,17 @@ mod tests {
         let samwise = Address::generate(&e);
 
         let backstop_emissions_data = BackstopEmissionData {
-            expiration: BACKSTOP_EPOCH + 7 * 24 * 60 * 60,
+            expiration: 1713139200 + 7 * 24 * 60 * 60,
             eps: 0_10000000000000,
             index: 222220000000,
-            last_time: BACKSTOP_EPOCH,
+            last_time: 1713139200,
         };
         let user_emissions_data = UserEmissionData {
             index: 345660000000000 + 1,
             accrued: 3,
         };
         e.as_contract(&backstop_id, || {
-            storage::set_last_distribution_time(&e, &BACKSTOP_EPOCH);
+            storage::set_last_distribution_time(&e, &1713139200);
 
             storage::set_backstop_emis_data(&e, &pool_1, &backstop_emissions_data);
             storage::set_user_emis_data(&e, &pool_1, &samwise, &user_emissions_data);

--- a/backstop/src/emissions/distributor.rs
+++ b/backstop/src/emissions/distributor.rs
@@ -1,5 +1,7 @@
 //! Methods for distributing backstop emissions to depositors
 
+use std::println;
+
 use cast::i128;
 use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::{unwrap::UnwrapOptimized, Address, Env};
@@ -82,6 +84,10 @@ pub fn update_emission_data(
                 index: additional_idx + emis_data.index,
                 last_time: e.ledger().timestamp(),
             };
+            println!(
+                "expiration: {} , index: {}, additional_index: {}, unqueued_shares: {}",
+                new_data.expiration, new_data.index, additional_idx, unqueued_shares
+            );
             storage::set_backstop_emis_data(e, pool_id, &new_data);
             Some(new_data)
         }

--- a/backstop/src/emissions/mod.rs
+++ b/backstop/src/emissions/mod.rs
@@ -5,4 +5,6 @@ mod distributor;
 pub use distributor::update_emissions;
 
 mod manager;
-pub use manager::{add_to_reward_zone, distribute, gulp_emissions, remove_from_reward_zone};
+pub use manager::{
+    add_to_reward_zone, distribute, gulp_emissions, remove_from_reward_zone, update_rz_emis_data,
+};

--- a/backstop/src/emissions/mod.rs
+++ b/backstop/src/emissions/mod.rs
@@ -5,4 +5,4 @@ mod distributor;
 pub use distributor::update_emissions;
 
 mod manager;
-pub use manager::{add_to_reward_zone, distribute, gulp_emissions};
+pub use manager::{add_to_reward_zone, distribute, gulp_emissions, remove_from_reward_zone};

--- a/backstop/src/emissions/mod.rs
+++ b/backstop/src/emissions/mod.rs
@@ -5,4 +5,4 @@ mod distributor;
 pub use distributor::update_emissions;
 
 mod manager;
-pub use manager::{add_to_reward_zone, gulp_emissions, gulp_pool_emissions};
+pub use manager::{add_to_reward_zone, distribute, gulp_emissions};

--- a/backstop/src/errors.rs
+++ b/backstop/src/errors.rs
@@ -25,4 +25,6 @@ pub enum BackstopError {
     InvalidShareMintAmount = 1005,
     InvalidTokenWithdrawAmount = 1006,
     TooManyQ4WEntries = 1007,
+    NotInRewardZone = 1008,
+    RewardZoneFull = 1009,
 }

--- a/backstop/src/events.rs
+++ b/backstop/src/events.rs
@@ -75,16 +75,35 @@ impl BackstopEvents {
         e.events().publish(topics, (amount, tokens_out));
     }
 
-    /// Emitted when new emissions are gulped
-    ///
-    /// - topics - `["gulp_emissions"]`
+    /// Emitted when new emissions are distributed
+    /// - topics - `["distribute"]`
     /// - data - `[new_tokens_emitted: i128]`
     ///
     /// ### Arguments
     /// * `new_tokens_emitted` - The amount of new tokens emitted
-    pub fn gulp_emissions(e: &Env, new_tokens_emitted: i128) {
-        let topics = (Symbol::new(e, "gulp_emissions"),);
+    pub fn distribute(e: &Env, new_tokens_emitted: i128) {
+        let topics = (Symbol::new(e, "distribute"),);
         e.events().publish(topics, new_tokens_emitted);
+    }
+
+    /// Emitted when new emissions are gulped
+    ///
+    /// - topics - `["gulp_emissions", pool_address: Address]`
+    /// - data - `[new_backstop_emissions: i128, new_pool_emissions: i128]`
+    ///
+    /// ### Arguments
+    /// * `pool_address` - The address of the pool that gulped emissions
+    /// * `new_backstop_emissions` - The amount of new emissions for the backstop
+    /// * `new_pool_emissions` - The amount of new emissions for the pool
+    pub fn gulp_emissions(
+        e: &Env,
+        pool_address: Address,
+        new_backstop_emissions: i128,
+        new_pool_emissions: i128,
+    ) {
+        let topics = (Symbol::new(e, "gulp_emissions"), pool_address);
+        e.events()
+            .publish(topics, (new_backstop_emissions, new_pool_emissions));
     }
 
     /// Emitted when the reward zone is updated
@@ -95,7 +114,7 @@ impl BackstopEvents {
     /// ### Arguments
     /// * `to_add` - The address to add to the reward zone
     /// * `to_remove` - The address to remove from the reward zone
-    pub fn rw_zone(e: &Env, to_add: Address, to_remove: Address) {
+    pub fn rw_zone(e: &Env, to_add: Address, to_remove: Option<Address>) {
         let topics = (Symbol::new(e, "rw_zone"),);
         e.events().publish(topics, (to_add, to_remove));
     }

--- a/backstop/src/events.rs
+++ b/backstop/src/events.rs
@@ -108,15 +108,27 @@ impl BackstopEvents {
 
     /// Emitted when the reward zone is updated
     ///
-    /// - topics - `["rw_zone"]`
+    /// - topics - `["rw_zone_add"]`
     /// - data - `[to_add: Address, to_remove: Address]`
     ///
     /// ### Arguments
     /// * `to_add` - The address to add to the reward zone
     /// * `to_remove` - The address to remove from the reward zone
-    pub fn rw_zone(e: &Env, to_add: Address, to_remove: Option<Address>) {
-        let topics = (Symbol::new(e, "rw_zone"),);
+    pub fn rw_zone_add(e: &Env, to_add: Address, to_remove: Option<Address>) {
+        let topics = (Symbol::new(e, "rw_zone_add"),);
         e.events().publish(topics, (to_add, to_remove));
+    }
+
+    /// Emitted when a pool is removed from the reward zone
+    ///
+    /// - topics - `["rw_zone_remove", pool_address: Address]`
+    /// - data - `[to_remove: Address]`
+    ///
+    /// ### Arguments
+    /// * `to_remove` - The address to remove from the reward zone
+    pub fn rw_zone_remove(e: &Env, to_remove: Address) {
+        let topics = (Symbol::new(e, "rw_zone_remove"),);
+        e.events().publish(topics, to_remove);
     }
 
     /// Emitted when emissions are claimed

--- a/mocks/mock-pool-factory/src/pool_factory.rs
+++ b/mocks/mock-pool-factory/src/pool_factory.rs
@@ -1,5 +1,3 @@
-use std::println;
-
 use crate::{
     storage::{self, PoolInitMeta},
     PoolFactoryError,
@@ -91,7 +89,6 @@ impl MockPoolFactoryTrait for MockPoolFactory {
 
         let pool_address = Address::generate(&e);
         e.register_at(&pool_address, PoolContract {}, ());
-        println!("{:?}", pool_address);
         e.invoke_contract::<Val>(&pool_address, &Symbol::new(&e, "initialize"), init_args);
 
         storage::set_deployed(&e, &pool_address);

--- a/mocks/mock-pool-factory/src/pool_factory.rs
+++ b/mocks/mock-pool-factory/src/pool_factory.rs
@@ -1,10 +1,12 @@
+use std::println;
+
 use crate::{
     storage::{self, PoolInitMeta},
     PoolFactoryError,
 };
 use soroban_sdk::{
-    contract, contractimpl, panic_with_error, vec, Address, BytesN, Env, IntoVal, String, Symbol,
-    Val, Vec,
+    contract, contractimpl, panic_with_error, testutils::Address as _, vec, Address, BytesN, Env,
+    IntoVal, String, Symbol, Val, Vec,
 };
 
 use pool::PoolContract;
@@ -87,7 +89,9 @@ impl MockPoolFactoryTrait for MockPoolFactory {
         init_args.push_back(pool_init_meta.backstop.to_val());
         init_args.push_back(pool_init_meta.blnd_id.to_val());
 
-        let pool_address = e.register(PoolContract {}, ());
+        let pool_address = Address::generate(&e);
+        e.register_at(&pool_address, PoolContract {}, ());
+        println!("{:?}", pool_address);
         e.invoke_contract::<Val>(&pool_address, &Symbol::new(&e, "initialize"), init_args);
 
         storage::set_deployed(&e, &pool_address);

--- a/pool/src/emissions/distributor.rs
+++ b/pool/src/emissions/distributor.rs
@@ -410,7 +410,7 @@ mod tests {
         let samwise = Address::generate(&e);
 
         e.ledger().set(LedgerInfo {
-            timestamp: 1501000000, // 10^6 seconds have passed
+            timestamp: 1510000000, // 10^7 seconds have passed
             protocol_version: 22,
             sequence_number: 123,
             network_id: Default::default(),
@@ -425,7 +425,7 @@ mod tests {
         e.as_contract(&pool, || {
             let reserve_emission_data = ReserveEmissionData {
                 expiration: 1600000000,
-                eps: 0_01000000000000,
+                eps: 100_00000000000000,
                 index: 23456780000000,
                 last_time: 1500000000,
             };
@@ -439,6 +439,8 @@ mod tests {
             storage::set_res_emis_data(&e, &res_token_index, &reserve_emission_data);
             storage::set_user_emissions(&e, &samwise, &res_token_index, &user_emission_data);
 
+            // Intermediate index math should not overflow using SorobanFixedPoint
+            // 10^7 * 10^16 * 10^18 = 10^41 > i128::MAX
             update_emissions(
                 &e,
                 res_token_index,
@@ -452,12 +454,12 @@ mod tests {
                 storage::get_res_emis_data(&e, &res_token_index).unwrap_optimized();
             let new_user_emission_data =
                 storage::get_user_emissions(&e, &samwise, &res_token_index).unwrap_optimized();
-            assert_eq!(new_reserve_emission_data.last_time, 1501000000);
+            assert_eq!(new_reserve_emission_data.last_time, 1510000000);
             assert_eq!(
                 new_user_emission_data.index,
                 new_reserve_emission_data.index
             );
-            assert_eq!(new_user_emission_data.accrued, 2111111);
+            assert_eq!(new_user_emission_data.accrued, 2121111);
         });
     }
 

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -478,8 +478,6 @@ mod tests {
         });
     }
 
-
-
     #[test]
     #[should_panic(expected = "Error(Contract, #9)")]
     fn test_submit_use_allowance_no_allowance() {

--- a/pool/src/pool/user.rs
+++ b/pool/src/pool/user.rs
@@ -407,8 +407,8 @@ mod tests {
 
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
             let new_index = 10000000000
-                + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_d_supply_0, SCALAR_7 * SCALAR_7)
+                + (1000i128 * 0_10000000000000)
+                    .fixed_div_floor(starting_d_supply_0, SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);

--- a/pool/src/pool/user.rs
+++ b/pool/src/pool/user.rs
@@ -378,12 +378,12 @@ mod tests {
 
         let emis_res_data = ReserveEmissionData {
             expiration: 20000000,
-            eps: 0_1000000,
-            index: 1000,
+            eps: 0_10000000000000,
+            index: 10000000000,
             last_time: 10000000, // 1000s elapsed
         };
         let emis_user_data = UserEmissionData {
-            index: 900,
+            index: 9000000000,
             accrued: 0,
         };
 
@@ -406,9 +406,9 @@ mod tests {
             assert_eq!(reserve_0.d_supply, starting_d_supply_0 + 123);
 
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
-            let new_index = 1000
+            let new_index = 10000000000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_d_supply_0, SCALAR_7)
+                    .fixed_div_floor(starting_d_supply_0, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -416,7 +416,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, SCALAR_7)
+                    .fixed_mul_floor(1000, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -467,12 +467,12 @@ mod tests {
 
         let emis_res_data = ReserveEmissionData {
             expiration: 20000000,
-            eps: 0_1000000,
-            index: 1000,
+            eps: 0_10000000000000,
+            index: 10000000000,
             last_time: 10000000, // 1000s elapsed
         };
         let emis_user_data = UserEmissionData {
-            index: 900,
+            index: 9000000000,
             accrued: 0,
         };
         let mut user = User {
@@ -493,9 +493,9 @@ mod tests {
             assert_eq!(reserve_0.d_supply, starting_d_supply_0 - 123);
 
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
-            let new_index = 1000
+            let new_index = 10000000000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_d_supply_0, SCALAR_7)
+                    .fixed_div_floor(starting_d_supply_0, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -503,7 +503,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, SCALAR_7)
+                    .fixed_mul_floor(1000, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -682,12 +682,12 @@ mod tests {
 
         let emis_res_data = ReserveEmissionData {
             expiration: 20000000,
-            eps: 0_1000000,
-            index: 1000,
+            eps: 0_10000000000000,
+            index: 10000000000,
             last_time: 10000000, // 1000s elapsed
         };
         let emis_user_data = UserEmissionData {
-            index: 900,
+            index: 9000000000,
             accrued: 0,
         };
 
@@ -709,9 +709,9 @@ mod tests {
             assert_eq!(reserve_0.b_supply, starting_b_token_supply + 123);
 
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
-            let new_index = 1000
+            let new_index = 10000000000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -719,7 +719,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, SCALAR_7)
+                    .fixed_mul_floor(1000, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -770,12 +770,12 @@ mod tests {
 
         let emis_res_data = ReserveEmissionData {
             expiration: 20000000,
-            eps: 0_1000000,
-            index: 1000,
+            eps: 0_10000000000000,
+            index: 10000000000,
             last_time: 10000000, // 1000s elapsed
         };
         let emis_user_data = UserEmissionData {
-            index: 900,
+            index: 9000000000,
             accrued: 0,
         };
 
@@ -797,9 +797,9 @@ mod tests {
             assert_eq!(reserve_0.b_supply, starting_b_token_supply - 123);
 
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
-            let new_index = 1000
+            let new_index = 10000000000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -807,7 +807,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, SCALAR_7)
+                    .fixed_mul_floor(1000, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -916,12 +916,12 @@ mod tests {
 
         let emis_res_data = ReserveEmissionData {
             expiration: 20000000,
-            eps: 0_1000000,
-            index: 1000,
+            eps: 0_10000000000000,
+            index: 10000000000,
             last_time: 10000000, // 1000s elapsed
         };
         let emis_user_data = UserEmissionData {
-            index: 900,
+            index: 9000000000,
             accrued: 0,
         };
 
@@ -943,9 +943,9 @@ mod tests {
             assert_eq!(reserve_0.b_supply, starting_b_token_supply + 123);
 
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
-            let new_index = 1000
+            let new_index = 10000000000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -953,7 +953,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, SCALAR_7)
+                    .fixed_mul_floor(1000, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -1004,12 +1004,12 @@ mod tests {
 
         let emis_res_data = ReserveEmissionData {
             expiration: 20000000,
-            eps: 0_1000000,
-            index: 1000,
+            eps: 0_10000000000000,
+            index: 10000000000,
             last_time: 10000000, // 1000s elapsed
         };
         let emis_user_data = UserEmissionData {
-            index: 900,
+            index: 9000000000,
             accrued: 0,
         };
 
@@ -1031,9 +1031,9 @@ mod tests {
             assert_eq!(reserve_0.b_supply, starting_b_token_supply - 123);
 
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
-            let new_index = 1000
+            let new_index = 10000000000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -1041,7 +1041,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, SCALAR_7)
+                    .fixed_mul_floor(1000, SCALAR_7 * SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });

--- a/test-suites/src/setup.rs
+++ b/test-suites/src/setup.rs
@@ -1,5 +1,5 @@
 use pool::{Request, RequestType, ReserveEmissionMetadata};
-use soroban_sdk::{testutils::Address as _, vec as svec, Address, String, Vec as SVec};
+use soroban_sdk::{vec as svec, String, Vec as SVec};
 
 use crate::{
     pool::default_reserve_metadata,
@@ -74,13 +74,13 @@ pub fn create_fixture_with_data<'a>(wasm: bool) -> TestFixture<'a> {
     fixture.backstop.update_tkn_val();
     fixture
         .backstop
-        .add_reward(&pool_fixture.pool.address, &Address::generate(&fixture.env));
+        .add_reward(&pool_fixture.pool.address, &None);
     pool_fixture.pool.set_status(&3);
     pool_fixture.pool.update_status();
 
     // enable emissions
     fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
+    fixture.backstop.distribute();
     pool_fixture.pool.gulp_emissions();
 
     fixture.jump(60);
@@ -196,7 +196,7 @@ mod tests {
             fixture.env.ledger().timestamp() - 60 * 61
         );
         assert_eq!(emis_data.index, 0);
-        assert_eq!(0_180_0000, emis_data.eps);
+        assert_eq!(0_180_0000_0000000, emis_data.eps);
         assert_eq!(
             fixture.env.ledger().timestamp() + 7 * 24 * 60 * 60 - 60 * 61,
             emis_data.expiration
@@ -253,7 +253,7 @@ mod tests {
             fixture.env.ledger().timestamp() - 60 * 61
         );
         assert_eq!(emis_data.index, 0);
-        assert_eq!(0_180_0000, emis_data.eps);
+        assert_eq!(0_180_0000_0000000, emis_data.eps);
         assert_eq!(
             fixture.env.ledger().timestamp() + 7 * 24 * 60 * 60 - 60 * 61,
             emis_data.expiration

--- a/test-suites/tests/test_backstop.rs
+++ b/test-suites/tests/test_backstop.rs
@@ -141,6 +141,18 @@ fn test_backstop() {
     // Start the next emission cycle
     fixture.emitter.distribute();
     fixture.backstop.distribute();
+    let event = vec![&fixture.env, fixture.env.events().all().last_unchecked()];
+    assert_eq!(
+        event,
+        vec![
+            &fixture.env,
+            (
+                fixture.backstop.address.clone(),
+                (Symbol::new(&fixture.env, "distribute"),).into_val(&fixture.env),
+                ((60 * 60 * 24 * 7 + 60) * SCALAR_7).into_val(&fixture.env),
+            )
+        ]
+    );
     pool.gulp_emissions();
     let amount = 2_000 * SCALAR_7;
     fixture.lp.approve(

--- a/test-suites/tests/test_backstop.rs
+++ b/test-suites/tests/test_backstop.rs
@@ -138,6 +138,10 @@ fn test_backstop() {
     // Simulate the pool backstop making money and progress 6d23h (6d23hr total emissions for sam)
     // @dev: setup jumps 1 hour and 1 minute
     fixture.jump(60 * 60 * 24 * 7 - 60 * 60);
+    // Start the next emission cycle
+    fixture.emitter.distribute();
+    fixture.backstop.distribute();
+    pool.gulp_emissions();
     let amount = 2_000 * SCALAR_7;
     fixture.lp.approve(
         &frodo,
@@ -209,9 +213,6 @@ fn test_backstop() {
         ]
     );
 
-    // Start the next emission cycle
-    fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
     assert_eq!(fixture.env.auths().len(), 0);
 
     // Sam queues 100% of position for withdrawal
@@ -274,7 +275,8 @@ fn test_backstop() {
     // Start the next emission cycle and jump 7 days (13d23hr total emissions for sam)
     fixture.jump(60 * 60 * 24 * 7);
     fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
+    fixture.backstop.distribute();
+    pool.gulp_emissions();
 
     // Sam dequeues half of the withdrawal
     let amount = 6_250 * SCALAR_7; // shares
@@ -326,7 +328,8 @@ fn test_backstop() {
     // Start the next emission cycle and jump 7 days (20d23hr total emissions for sam)
     fixture.jump(60 * 60 * 24 * 7);
     fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
+    fixture.backstop.distribute();
+    pool.gulp_emissions();
 
     // Backstop loses money
     let amount = 1_000 * SCALAR_7;
@@ -373,7 +376,6 @@ fn test_backstop() {
 
     // Jump to the end of the withdrawal period (27d23hr total emissions for sam)
     fixture.jump(60 * 60 * 24 * 16 + 1);
-
     // Sam withdraws the queue position
     let amount = 6_250 * SCALAR_7; // shares
     let result = fixture.backstop.withdraw(&sam, &pool.address, &amount);
@@ -460,7 +462,7 @@ fn test_backstop() {
     let emitted_blnd_1 = ((7 * 24 * 60 * 60 - 61 * 60) * SCALAR_7)
         .fixed_mul_floor(emission_share_1, SCALAR_7)
         .unwrap();
-    let emitted_blnd_2 = ((14 * 24 * 60 * 60 + 1) * SCALAR_7 + 2096022)
+    let emitted_blnd_2 = ((14 * 24 * 60 * 60 + 1) * SCALAR_7 + 2096012)
         .fixed_mul_floor(emission_share_2, SCALAR_7)
         .unwrap();
 

--- a/test-suites/tests/test_backstop_rz_changes.rs
+++ b/test-suites/tests/test_backstop_rz_changes.rs
@@ -1,0 +1,103 @@
+#![cfg(test)]
+use soroban_fixed_point_math::FixedPoint;
+use soroban_sdk::{
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
+    vec, Address, IntoVal, String, Symbol, Val, Vec,
+};
+use test_suites::{
+    assertions::assert_approx_eq_abs,
+    create_fixture_with_data,
+    pool::default_reserve_metadata,
+    test_fixture::{TokenIndex, SCALAR_7},
+};
+
+/// Test backstop RZ changes correctly handle emissions tracking
+#[test]
+fn test_backstop_rz_changes_handle_emissions() {
+    let fixture = create_fixture_with_data(false);
+    let bstop_token = &fixture.lp;
+    let sam = Address::generate(&fixture.env);
+    let frodo = &fixture.users[0];
+    let pool_fixture = &fixture.pools[0];
+
+    // Mint some backstop tokens
+    // assumes Sam makes up 20% of the backstop after depositing (50k / 0.8 * 0.2 = 12.5k)
+    //  -> mint 12.5k LP tokens to sam
+    fixture.tokens[TokenIndex::BLND].mint(&sam, &(125_001_000_0000_0000_000_000 * SCALAR_7)); // 10 BLND per LP token
+    fixture.tokens[TokenIndex::BLND].approve(&sam, &bstop_token.address, &i128::MAX, &99999);
+    fixture.tokens[TokenIndex::USDC].mint(&sam, &(3_126_000_0000_0000_000_000 * SCALAR_7)); // 0.25 USDC per LP token
+    fixture.tokens[TokenIndex::USDC].approve(&sam, &bstop_token.address, &i128::MAX, &99999);
+    bstop_token.join_pool(
+        &(12_500 * SCALAR_7),
+        &vec![
+            &fixture.env,
+            125_001_000_0000_0000_000 * SCALAR_7,
+            3_126_000_0000_0000_000 * SCALAR_7,
+        ],
+        &sam,
+    );
+    fixture
+        .backstop
+        .deposit(&sam, &pool_fixture.pool.address, &(12_500 * SCALAR_7));
+    fixture
+        .backstop
+        .queue_withdrawal(frodo, &pool_fixture.pool.address, &(45000 * SCALAR_7));
+
+    fixture.jump(60 * 60 * 24 * 21);
+    fixture.emitter.distribute();
+    fixture.backstop.distribute();
+    pool_fixture.pool.gulp_emissions();
+    fixture
+        .backstop
+        .withdraw(frodo, &pool_fixture.pool.address, &(45000 * SCALAR_7));
+    let result = fixture.backstop.claim(
+        &sam,
+        &vec![&fixture.env, pool_fixture.pool.address.clone()],
+        &sam,
+    );
+    assert_eq!(result, 3005700000000);
+
+    fixture.backstop.remove_reward(&pool_fixture.pool.address);
+
+    let result = pool_fixture.pool.try_gulp_emissions();
+    assert!(result.is_err());
+
+    // claim 3 days later
+    fixture.jump(60 * 60 * 24 * 3);
+    let result = fixture.backstop.claim(
+        &sam,
+        &vec![&fixture.env, pool_fixture.pool.address.clone()],
+        &sam,
+    );
+    assert_eq!(result, 4797429238475);
+
+    fixture.jump(60 * 60 * 24 * 4);
+    let result = fixture.backstop.claim(
+        &sam,
+        &vec![&fixture.env, pool_fixture.pool.address.clone()],
+        &sam,
+    );
+    assert_eq!(result, 6816808840184);
+
+    fixture.jump(1);
+    let result = fixture.backstop.claim(
+        &sam,
+        &vec![&fixture.env, pool_fixture.pool.address.clone()],
+        &sam,
+    );
+    assert_eq!(result, 0);
+
+    fixture
+        .backstop
+        .deposit(frodo, &pool_fixture.pool.address, &(45000 * SCALAR_7));
+
+    fixture
+        .backstop
+        .add_reward(&pool_fixture.pool.address, &None);
+
+    fixture.emitter.distribute();
+    fixture.backstop.distribute();
+
+    let result = pool_fixture.pool.gulp_emissions();
+    assert_eq!(result, 1814403000000); // (60 * 60 * 24 * 7 + 1) * 0.3
+}

--- a/test-suites/tests/test_backstop_rz_changes.rs
+++ b/test-suites/tests/test_backstop_rz_changes.rs
@@ -1,13 +1,7 @@
 #![cfg(test)]
-use soroban_fixed_point_math::FixedPoint;
-use soroban_sdk::{
-    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
-    vec, Address, IntoVal, String, Symbol, Val, Vec,
-};
+use soroban_sdk::{testutils::Address as _, vec, Address};
 use test_suites::{
-    assertions::assert_approx_eq_abs,
     create_fixture_with_data,
-    pool::default_reserve_metadata,
     test_fixture::{TokenIndex, SCALAR_7},
 };
 
@@ -99,5 +93,5 @@ fn test_backstop_rz_changes_handle_emissions() {
     fixture.backstop.distribute();
 
     let result = pool_fixture.pool.gulp_emissions();
-    assert_eq!(result, 1814403000000); // (60 * 60 * 24 * 7 + 1) * 0.3
+    assert_eq!(result, 1814402999999); // (60 * 60 * 24 * 7 + 1) * 0.3
 }

--- a/test-suites/tests/test_backstop_rz_changes.rs
+++ b/test-suites/tests/test_backstop_rz_changes.rs
@@ -32,7 +32,7 @@ fn test_backstop_rz_changes_handle_emissions() {
     );
     fixture
         .backstop
-        .deposit(&sam, &pool_fixture.pool.address, &(12_500 * SCALAR_7));
+        .deposit(&sam, &pool_fixture.pool.address, &(12500 * SCALAR_7));
     fixture
         .backstop
         .queue_withdrawal(frodo, &pool_fixture.pool.address, &(45000 * SCALAR_7));
@@ -44,12 +44,6 @@ fn test_backstop_rz_changes_handle_emissions() {
     fixture
         .backstop
         .withdraw(frodo, &pool_fixture.pool.address, &(45000 * SCALAR_7));
-    let result = fixture.backstop.claim(
-        &sam,
-        &vec![&fixture.env, pool_fixture.pool.address.clone()],
-        &sam,
-    );
-    assert_eq!(result, 3005700000000);
 
     fixture.backstop.remove_reward(&pool_fixture.pool.address);
 
@@ -63,7 +57,7 @@ fn test_backstop_rz_changes_handle_emissions() {
         &vec![&fixture.env, pool_fixture.pool.address.clone()],
         &sam,
     );
-    assert_eq!(result, 4797429238475);
+    assert_eq!(result, 6901542857142);
 
     fixture.jump(60 * 60 * 24 * 4);
     let result = fixture.backstop.claim(
@@ -71,7 +65,7 @@ fn test_backstop_rz_changes_handle_emissions() {
         &vec![&fixture.env, pool_fixture.pool.address.clone()],
         &sam,
     );
-    assert_eq!(result, 6816808840184);
+    assert_eq!(result, 6771681835261);
 
     fixture.jump(1);
     let result = fixture.backstop.claim(
@@ -83,7 +77,7 @@ fn test_backstop_rz_changes_handle_emissions() {
 
     fixture
         .backstop
-        .deposit(frodo, &pool_fixture.pool.address, &(45000 * SCALAR_7));
+        .deposit(frodo, &pool_fixture.pool.address, &(50000 * SCALAR_7));
 
     fixture
         .backstop

--- a/test-suites/tests/test_backstop_rz_changes.rs
+++ b/test-suites/tests/test_backstop_rz_changes.rs
@@ -93,5 +93,7 @@ fn test_backstop_rz_changes_handle_emissions() {
     fixture.backstop.distribute();
 
     let result = pool_fixture.pool.gulp_emissions();
+
+    // Emissions are distributed to the pool because the reward zone was empty when the backstop was added
     assert_eq!(result, 1814402999999); // (60 * 60 * 24 * 7 + 1) * 0.3
 }

--- a/test-suites/tests/test_emitter.rs
+++ b/test-suites/tests/test_emitter.rs
@@ -85,7 +85,7 @@ fn test_emitter_no_reward_zone() {
     fixture.jump(6 * 24 * 60 * 60);
     let result = fixture.emitter.distribute();
     assert_eq!(result, (13 * 24 * 60 * 60) * SCALAR_7); // 1 token per second are emitted
-    let result = fixture.backstop.try_gulp_emissions();
+    let result = fixture.backstop.try_distribute();
     assert!(result.is_err());
 
     assert_eq!(fixture.env.auths().len(), 0);
@@ -129,9 +129,9 @@ fn test_emitter_no_reward_zone() {
 
     fixture
         .backstop
-        .add_reward(&pool_fixture.pool.address, &Address::generate(&fixture.env));
-    fixture.backstop.gulp_emissions();
-
+        .add_reward(&pool_fixture.pool.address, &None);
+    let result = fixture.backstop.distribute();
+    assert_eq!(result, (13 * 24 * 60 * 60) * SCALAR_7);
     let result = pool_fixture.pool.gulp_emissions();
     assert_eq!(result, (13 * 24 * 60 * 60) * 300_0000);
     // Let some time go by
@@ -144,14 +144,14 @@ fn test_emitter_no_reward_zone() {
     );
     let post_claim_1_balance = blnd_token.balance(&fixture.users[0]);
     assert_eq!(post_claim_1_balance - pre_claim_balance, result);
-    assert_eq!(result, (13 * 24 * 60 * 60) * 300_0000 - 400000); //pool claim is only 30% of the total emissions - subtracting 400000 for rounding
+    assert_eq!(result, (13 * 24 * 60 * 60) * 300_0000 - 1); //pool claim is only 30% of the total emissions - subtracting 1 for rounding
     let result_1 = fixture.backstop.claim(
         &fixture.users[0],
         &svec![&fixture.env, pool_fixture.pool.address.clone()],
         &fixture.users[0],
     );
     assert_eq!(result_1, (13 * 24 * 60 * 60) * 700_0000);
-    assert_eq!(result_1 + result, (13 * 24 * 60 * 60) * SCALAR_7 - 400000);
+    assert_eq!(result_1 + result, (13 * 24 * 60 * 60) * SCALAR_7 - 1);
 }
 
 /// Test user exposed functions on the emitter for basic functionality, auth, and events.

--- a/test-suites/tests/test_liquidation.rs
+++ b/test-suites/tests/test_liquidation.rs
@@ -181,7 +181,7 @@ fn test_liquidations() {
         fixture.jump(60 * 60 * 24 * 7);
         // Update emissions
         fixture.emitter.distribute();
-        fixture.backstop.gulp_emissions();
+        fixture.backstop.distribute();
         pool_fixture.pool.gulp_emissions();
     }
     // Start an interest auction

--- a/test-suites/tests/test_pool.rs
+++ b/test-suites/tests/test_pool.rs
@@ -355,7 +355,7 @@ fn test_pool_user() {
     // allow the rest of the emissions period to pass (6 days - 5d23h59m emitted for XLM supply)
     fixture.jump(6 * 24 * 60 * 60);
     fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
+    fixture.backstop.distribute();
     pool_fixture.pool.gulp_emissions();
     assert_eq!(fixture.env.auths().len(), 0); // no auth required to update emissions
 
@@ -508,7 +508,7 @@ fn test_pool_user() {
             }
         )
     );
-    assert_eq!(result, 2940_3113155); // ~ 4.99k / (100k + 4.99k) * 0.12 (xlm eps) * 5d23hr59m in seconds
+    assert_eq!(result, 2940_3117289); // ~ 4.99k / (100k + 4.99k) * 0.12 (xlm eps) * 5d23hr59m in seconds
     assert_eq!(blnd.balance(&sam), sam_blnd_balance + result);
     let event = vec![&fixture.env, fixture.env.events().all().last_unchecked()];
     assert_eq!(

--- a/test-suites/tests/test_wasm_happy_path.rs
+++ b/test-suites/tests/test_wasm_happy_path.rs
@@ -433,8 +433,8 @@ fn test_wasm_happy_path() {
         &vec![&fixture.env, pool_fixture.pool.address.clone()],
         &frodo,
     );
-    assert_eq!(claim_amount, 22014719_9999995); //actual amount is 22014720_0000000 but get's rounded down
-    backstop_blnd_balance -= 22014719_9999995;
+    assert_eq!(claim_amount, 22014719_9999997); //actual amount is 22014720_0000000 but get's rounded down
+    backstop_blnd_balance -= 22014719_9999997;
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance
@@ -456,7 +456,7 @@ fn test_wasm_happy_path() {
         .pool
         .claim(&sam, &vec![&fixture.env, 0, 3], &sam);
     backstop_blnd_balance -= claim_amount;
-    assert_eq!(claim_amount, 8361251_8179827);
+    assert_eq!(claim_amount, 8361251_8179829);
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance

--- a/test-suites/tests/test_wasm_happy_path.rs
+++ b/test-suites/tests/test_wasm_happy_path.rs
@@ -212,7 +212,7 @@ fn test_wasm_happy_path() {
         .pool
         .claim(&frodo, &vec![&fixture.env, 0, 3], &frodo);
     backstop_blnd_balance -= claim_amount;
-    assert_eq!(claim_amount, 4665_6384000);
+    assert_eq!(claim_amount, 4665_6412742);
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance
@@ -228,7 +228,7 @@ fn test_wasm_happy_path() {
         .pool
         .claim(&sam, &vec![&fixture.env, 0, 3], &sam);
     backstop_blnd_balance -= claim_amount;
-    assert_eq!(claim_amount, 730943066650);
+    assert_eq!(claim_amount, 730943587256);
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance
@@ -365,7 +365,7 @@ fn test_wasm_happy_path() {
 
     // Distribute emissions
     fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
+    fixture.backstop.distribute();
     pool_fixture.pool.gulp_emissions();
 
     // Frodo claim emissions
@@ -376,7 +376,7 @@ fn test_wasm_happy_path() {
         .pool
         .claim(&frodo, &vec![&fixture.env, 0, 3], &frodo);
     backstop_blnd_balance -= claim_amount;
-    assert_eq!(claim_amount, 11673_1656000);
+    assert_eq!(claim_amount, 11673_1666080);
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance
@@ -391,7 +391,7 @@ fn test_wasm_happy_path() {
         &vec![&fixture.env, pool_fixture.pool.address.clone()],
         &frodo,
     );
-    assert_eq!(claim_amount, 420797_9972539);
+    assert_eq!(claim_amount, 420797_9999999);
     backstop_blnd_balance -= claim_amount;
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
@@ -404,7 +404,7 @@ fn test_wasm_happy_path() {
         .pool
         .claim(&sam, &vec![&fixture.env, 0, 3], &sam);
     backstop_blnd_balance -= claim_amount;
-    assert_eq!(claim_amount, 90908_8243725);
+    assert_eq!(claim_amount, 90908_8333918);
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance
@@ -417,12 +417,12 @@ fn test_wasm_happy_path() {
     // Let 51 weeks go by and call update to validate emissions won't get missed
     fixture.jump(60 * 60 * 24 * 7 * 51);
     fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
+    fixture.backstop.distribute();
     pool_fixture.pool.gulp_emissions();
     // Allow another week go by to distribute missed emissions
     fixture.jump(60 * 60 * 24 * 7);
     fixture.emitter.distribute();
-    fixture.backstop.gulp_emissions();
+    fixture.backstop.distribute();
     pool_fixture.pool.gulp_emissions();
 
     // Frodo claims a year worth of backstop emissions
@@ -433,8 +433,8 @@ fn test_wasm_happy_path() {
         &vec![&fixture.env, pool_fixture.pool.address.clone()],
         &frodo,
     );
-    assert_eq!(claim_amount, 22014719_9950114); //actual amount is 22014720_0000000 but get's rounded down
-    backstop_blnd_balance -= 22014719_9950114;
+    assert_eq!(claim_amount, 22014719_9999995); //actual amount is 22014720_0000000 but get's rounded down
+    backstop_blnd_balance -= 22014719_9999995;
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance
@@ -445,7 +445,7 @@ fn test_wasm_happy_path() {
         .pool
         .claim(&frodo, &vec![&fixture.env, 0, 3], &frodo);
     backstop_blnd_balance -= claim_amount;
-    assert_eq!(claim_amount, 1073628_1628000);
+    assert_eq!(claim_amount, 1073628_1820163);
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance
@@ -456,7 +456,7 @@ fn test_wasm_happy_path() {
         .pool
         .claim(&sam, &vec![&fixture.env, 0, 3], &sam);
     backstop_blnd_balance -= claim_amount;
-    assert_eq!(claim_amount, 8361251_6449409);
+    assert_eq!(claim_amount, 8361251_8179827);
     assert_eq!(
         fixture.tokens[TokenIndex::BLND].balance(&fixture.backstop.address),
         backstop_blnd_balance


### PR DESCRIPTION
- Separate backstops emission distribution from emission gulping to prevent exceeding resource limits
- Increase emission decimals to 14 to reduce rounding loss
- Implement remove_reward to remove backstops that are below the threshold from the reward zone
fixes #8 