### PR TITLE
Review

### DIFF
--- a/backstop/src/backstop/fund_management.rs
+++ b/backstop/src/backstop/fund_management.rs
@@ -1,10 +1,6 @@
-use crate::{
-    constants::SCALAR_7, contract::require_nonnegative, dependencies::CometClient, storage,
-    BackstopError,
-};
+use crate::{contract::require_nonnegative, storage, BackstopError};
 use sep_41_token::TokenClient;
-use soroban_fixed_point_math::FixedPoint;
-use soroban_sdk::{panic_with_error, unwrap::UnwrapOptimized, Address, Env};
+use soroban_sdk::{panic_with_error, Address, Env};
 
 use super::require_is_from_pool_factory;
 
@@ -45,40 +41,13 @@ pub fn execute_donate(e: &Env, from: &Address, pool_address: &Address, amount: i
     storage::set_pool_balance(e, pool_address, &pool_balance);
 }
 
-/// Perform an update to the Comet LP token underlying value
-pub fn execute_update_comet_token_value(
-    e: &Env,
-    backstop_token: &Address,
-    blnd_token: &Address,
-    usdc_token: &Address,
-) -> (i128, i128) {
-    let total_comet_shares = CometClient::new(e, backstop_token).get_total_supply();
-    let total_blnd = TokenClient::new(e, &blnd_token).balance(backstop_token);
-    let total_usdc = TokenClient::new(e, &usdc_token).balance(backstop_token);
-
-    // underlying per LP token
-    let blnd_per_tkn = total_blnd
-        .fixed_div_floor(total_comet_shares, SCALAR_7)
-        .unwrap_optimized();
-    let usdc_per_tkn = total_usdc
-        .fixed_div_floor(total_comet_shares, SCALAR_7)
-        .unwrap_optimized();
-
-    let lp_token_val = (blnd_per_tkn, usdc_per_tkn);
-    storage::set_lp_token_val(e, &lp_token_val);
-    lp_token_val
-}
-
 #[cfg(test)]
 mod tests {
     use soroban_sdk::{testutils::Address as _, Address};
 
     use crate::{
         backstop::execute_deposit,
-        testutils::{
-            create_backstop, create_backstop_token, create_blnd_token, create_comet_lp_pool,
-            create_mock_pool_factory, create_usdc_token,
-        },
+        testutils::{create_backstop, create_backstop_token, create_mock_pool_factory},
     };
 
     use super::*;
@@ -323,39 +292,6 @@ mod tests {
 
         e.as_contract(&backstop_id, || {
             execute_draw(&e, &pool_0_id, -30_0000000, &samwise);
-        });
-    }
-
-    #[test]
-    fn test_execute_update_comet_token_value() {
-        let e = Env::default();
-        e.mock_all_auths_allowing_non_root_auth();
-        e.cost_estimate().budget().reset_unlimited();
-
-        let backstop_id = create_backstop(&e);
-        let bombadil = Address::generate(&e);
-        let samwise = Address::generate(&e);
-
-        let (usdc_token, usdc_token_client) = create_usdc_token(&e, &backstop_id, &bombadil);
-        usdc_token_client.mint(&samwise, &100_0000000);
-
-        let (blnd_token, blnd_token_client) = create_blnd_token(&e, &backstop_id, &bombadil);
-        blnd_token_client.mint(&samwise, &100_0000000);
-
-        let (comet_id, _) = create_comet_lp_pool(&e, &bombadil, &blnd_token, &usdc_token);
-
-        e.as_contract(&backstop_id, || {
-            storage::set_backstop_token(&e, &comet_id);
-
-            let (result_blnd_per_tkn, result_usdc_per_tkn) =
-                execute_update_comet_token_value(&e, &comet_id, &blnd_token, &usdc_token);
-
-            let (blnd_per_tkn, usdc_per_tkn) = storage::get_lp_token_val(&e);
-
-            assert_eq!(result_blnd_per_tkn, blnd_per_tkn);
-            assert_eq!(result_usdc_per_tkn, usdc_per_tkn);
-            assert_eq!(blnd_per_tkn, 10_0000000);
-            assert_eq!(usdc_per_tkn, 0_2500000);
         });
     }
 }

--- a/backstop/src/backstop/mod.rs
+++ b/backstop/src/backstop/mod.rs
@@ -2,7 +2,7 @@ mod deposit;
 pub use deposit::execute_deposit;
 
 mod fund_management;
-pub use fund_management::{execute_donate, execute_draw, execute_update_comet_token_value};
+pub use fund_management::{execute_donate, execute_draw};
 
 mod withdrawal;
 pub use withdrawal::{execute_dequeue_withdrawal, execute_queue_withdrawal, execute_withdraw};

--- a/backstop/src/contract.rs
+++ b/backstop/src/contract.rs
@@ -156,15 +156,6 @@ pub trait Backstop {
     /// If the `pool_address` is not valid, backstop does not have sufficient allowance from `from`, or if the pool does not
     /// authorize the call
     fn donate(e: Env, from: Address, pool_address: Address, amount: i128);
-
-    /// Updates the underlying value of 1 backstop token
-    ///
-    /// ### Returns
-    /// A tuple of (blnd_per_tkn, usdc_per_tkn) of underlying value per backstop token
-    ///
-    /// ### Errors
-    /// If the underlying value is unable to be computed
-    fn update_tkn_val(e: Env) -> (i128, i128);
 }
 
 #[contractimpl]
@@ -331,16 +322,6 @@ impl Backstop for BackstopContract {
         backstop::execute_donate(&e, &from, &pool_address, amount);
 
         BackstopEvents::donate(&e, pool_address, from, amount);
-    }
-
-    fn update_tkn_val(e: Env) -> (i128, i128) {
-        storage::extend_instance(&e);
-
-        let backstop_token = storage::get_backstop_token(&e);
-        let blnd_token = storage::get_blnd_token(&e);
-        let usdc_token = storage::get_usdc_token(&e);
-
-        backstop::execute_update_comet_token_value(&e, &backstop_token, &blnd_token, &usdc_token)
     }
 }
 

--- a/backstop/src/emissions/manager.rs
+++ b/backstop/src/emissions/manager.rs
@@ -308,7 +308,10 @@ mod tests {
 
     use crate::{
         backstop::PoolBalance,
-        testutils::{create_backstop, create_blnd_token, create_emitter},
+        testutils::{
+            create_backstop, create_blnd_token, create_comet_lp_pool_with_tokens_per_share,
+            create_emitter, create_usdc_token,
+        },
     };
 
     /********** gulp_emissions **********/
@@ -1173,9 +1176,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
 
         e.as_contract(&backstop_id, || {
             storage::set_pool_balance(
@@ -1187,7 +1204,6 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), None);
             let actual_rz = storage::get_reward_zone(&e);
@@ -1209,9 +1225,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![
             &e,
             Address::generate(&e),
@@ -1236,7 +1266,6 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), None);
             let actual_rz = storage::get_reward_zone(&e);
@@ -1259,9 +1288,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
 
         e.as_contract(&backstop_id, || {
             storage::set_pool_balance(
@@ -1273,7 +1316,7 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
+            // storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), None);
             let actual_rz = storage::get_reward_zone(&e);
@@ -1295,9 +1338,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![
             &e,
             Address::generate(&e),
@@ -1323,7 +1380,6 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), None);
             let actual_rz = storage::get_reward_zone(&e);
@@ -1331,6 +1387,7 @@ mod tests {
             assert_eq!(actual_rz, reward_zone);
         });
     }
+
     #[test]
     #[should_panic(expected = "Error(Contract, #1009)")]
     fn test_add_to_rz_respects_max_size() {
@@ -1346,9 +1403,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![&e];
         for _ in 0..50 {
             reward_zone.push_back(Address::generate(&e));
@@ -1364,7 +1435,6 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             // This should fail due to the reward zone being full and not having a pool to remove
             add_to_reward_zone(&e, to_add.clone(), None);
@@ -1387,9 +1457,24 @@ mod tests {
 
         let backstop_id = create_backstop(&e);
         create_blnd_token(&e, &backstop_id, &Address::generate(&e));
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
+        let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![&e];
         for _ in 0..50 {
             reward_zone.push_back(Address::generate(&e));
@@ -1436,7 +1521,6 @@ mod tests {
                 },
             );
             storage::set_rz_emission_index(&e, &(5678 * SCALAR_7));
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
             add_to_reward_zone(&e, to_add.clone(), Some(to_remove.clone()));
             let actual_rz = storage::get_reward_zone(&e);
             assert_eq!(actual_rz.len(), 50);
@@ -1465,10 +1549,24 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![&e];
         for _ in 0..50 {
             reward_zone.push_back(Address::generate(&e));
@@ -1496,7 +1594,6 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), Some(to_remove));
         });
@@ -1516,10 +1613,24 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![&e];
         for _ in 0..50 {
             reward_zone.push_back(Address::generate(&e));
@@ -1547,7 +1658,6 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), Some(to_remove));
         });
@@ -1567,10 +1677,24 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![&e];
         for _ in 0..50 {
             reward_zone.push_back(Address::generate(&e));
@@ -1597,7 +1721,7 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
+            // storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), Some(to_remove));
         });
@@ -1617,10 +1741,24 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
         let to_add = Address::generate(&e);
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let reward_zone: Vec<Address> = vec![
             &e,
             Address::generate(&e),
@@ -1656,7 +1794,7 @@ mod tests {
                     q4w: 1_000_0000000,
                 },
             );
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
+            // storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
 
             add_to_reward_zone(&e, to_add.clone(), Some(to_remove.clone()));
         });
@@ -1677,11 +1815,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
-        create_blnd_token(&e, &backstop_id, &Address::generate(&e));
-
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let mut reward_zone: Vec<Address> = vec![
             &e,
             Address::generate(&e),
@@ -1726,7 +1876,6 @@ mod tests {
                 }
             });
             storage::set_rz_emission_index(&e, &(5678 * SCALAR_7));
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
             remove_from_reward_zone(&e, to_remove.clone());
             let actual_rz = storage::get_reward_zone(&e);
             reward_zone.remove(1);
@@ -1753,11 +1902,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
-        create_blnd_token(&e, &backstop_id, &Address::generate(&e));
-
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let reward_zone: Vec<Address> = vec![
             &e,
             Address::generate(&e),
@@ -1793,7 +1954,6 @@ mod tests {
                 }
             });
             storage::set_rz_emission_index(&e, &(5678 * SCALAR_7));
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
             remove_from_reward_zone(&e, to_remove.clone());
         });
     }
@@ -1812,11 +1972,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
-        create_blnd_token(&e, &backstop_id, &Address::generate(&e));
-
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let reward_zone: Vec<Address> = vec![
             &e,
             Address::generate(&e),
@@ -1852,7 +2024,6 @@ mod tests {
                 }
             });
             storage::set_rz_emission_index(&e, &(5678 * SCALAR_7));
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
             remove_from_reward_zone(&e, to_remove.clone());
         });
     }
@@ -1871,11 +2042,23 @@ mod tests {
             min_persistent_entry_ttl: 10,
             max_entry_ttl: 3110400,
         });
+        e.mock_all_auths();
 
+        let bombadil = Address::generate(&e);
         let backstop_id = create_backstop(&e);
-        create_blnd_token(&e, &backstop_id, &Address::generate(&e));
-
         let to_remove = Address::generate(&e);
+
+        let (blnd_id, _) = create_blnd_token(&e, &backstop_id, &bombadil);
+        let (usdc_id, _) = create_usdc_token(&e, &backstop_id, &bombadil);
+        create_comet_lp_pool_with_tokens_per_share(
+            &e,
+            &backstop_id,
+            &bombadil,
+            &blnd_id,
+            5_0000000,
+            &usdc_id,
+            0_1000000,
+        );
         let reward_zone: Vec<Address> = vec![&e, Address::generate(&e)];
 
         e.as_contract(&backstop_id, || {
@@ -1907,7 +2090,6 @@ mod tests {
                 }
             });
             storage::set_rz_emission_index(&e, &(5678 * SCALAR_7));
-            storage::set_lp_token_val(&e, &(5_0000000, 0_1000000));
             remove_from_reward_zone(&e, to_remove.clone());
         });
     }

--- a/backstop/src/storage.rs
+++ b/backstop/src/storage.rs
@@ -60,7 +60,6 @@ const USDC_TOKEN_KEY: &str = "USDCTkn";
 const LAST_DISTRO_KEY: &str = "LastDist";
 const REWARD_ZONE_KEY: &str = "RZ";
 const DROP_LIST_KEY: &str = "DropList";
-const LP_TOKEN_VAL_KEY: &str = "LPTknVal";
 const RZ_EMISSION_INDEX_KEY: &str = "RZEmissionIndex";
 const BACKFILL_EMISSIONS_KEY: &str = "BackfillEmis";
 const BACKFILL_STATUS_KEY: &str = "Backfill";
@@ -531,35 +530,5 @@ pub fn set_drop_list(e: &Env, drop_list: &Vec<(Address, i128)>) {
         &Symbol::new(&e, DROP_LIST_KEY),
         LEDGER_THRESHOLD_USER,
         LEDGER_BUMP_USER,
-    );
-}
-
-/********** LP Token Value **********/
-
-/// Get the last updated token value for the LP pool
-pub fn get_lp_token_val(e: &Env) -> (i128, i128) {
-    e.storage().persistent().extend_ttl(
-        &Symbol::new(&e, LP_TOKEN_VAL_KEY),
-        LEDGER_THRESHOLD_SHARED,
-        LEDGER_BUMP_SHARED,
-    );
-    e.storage()
-        .persistent()
-        .get::<Symbol, (i128, i128)>(&Symbol::new(&e, LP_TOKEN_VAL_KEY))
-        .unwrap_optimized()
-}
-
-/// Set the reward zone
-///
-/// ### Arguments
-/// * `share_val` - A tuple of (blnd_per_share, usdc_per_share)
-pub fn set_lp_token_val(e: &Env, share_val: &(i128, i128)) {
-    e.storage()
-        .persistent()
-        .set::<Symbol, (i128, i128)>(&Symbol::new(&e, LP_TOKEN_VAL_KEY), share_val);
-    e.storage().persistent().extend_ttl(
-        &Symbol::new(&e, LP_TOKEN_VAL_KEY),
-        LEDGER_THRESHOLD_SHARED,
-        LEDGER_BUMP_SHARED,
     );
 }

--- a/pool/src/auctions/auction.rs
+++ b/pool/src/auctions/auction.rs
@@ -299,7 +299,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -423,7 +422,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
@@ -871,7 +869,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);

--- a/pool/src/auctions/backstop_interest_auction.rs
+++ b/pool/src/auctions/backstop_interest_auction.rs
@@ -435,7 +435,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
@@ -513,7 +512,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
@@ -591,7 +589,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
@@ -669,7 +666,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
@@ -781,7 +777,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
@@ -893,7 +888,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
@@ -1011,7 +1005,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -1143,7 +1136,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
 
         let (underlying_0, underlying_0_client) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();
@@ -1271,7 +1263,6 @@ mod tests {
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &backstop_token_id, &usdc_id, &blnd_id);
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
 
         let (underlying_0, underlying_0_client) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();

--- a/pool/src/auctions/backstop_interest_auction.rs
+++ b/pool/src/auctions/backstop_interest_auction.rs
@@ -101,12 +101,13 @@ pub fn fill_interest_auction(
     let backstop_client = BackstopClient::new(&e, &backstop);
     let backstop_token: Address = backstop_client.backstop_token();
     let backstop_token_bid_amount = auction_data.bid.get(backstop_token).unwrap_or(0);
-
-    backstop_client.donate(
-        &filler,
-        &e.current_contract_address(),
-        &backstop_token_bid_amount,
-    );
+    if backstop_token_bid_amount > 0 {
+        backstop_client.donate(
+            &filler,
+            &e.current_contract_address(),
+            &backstop_token_bid_amount,
+        );
+    }
 
     // lot contains underlying tokens, but the backstop credit must be updated on the reserve
     for (res_asset_address, lot_amount) in auction_data.lot.iter() {

--- a/pool/src/auctions/backstop_interest_auction.rs
+++ b/pool/src/auctions/backstop_interest_auction.rs
@@ -80,7 +80,7 @@ pub fn create_interest_auction_data(
             * 5)
         .fixed_div_floor(e, &pool_backstop_data.tokens, &SCALAR_7);
     let bid_amount = interest_value
-        .fixed_mul_floor(e, &1_4000000, &SCALAR_7)
+        .fixed_mul_floor(e, &1_2000000, &SCALAR_7)
         .fixed_div_floor(e, &backstop_token_value_base, &SCALAR_7);
     auction_data.bid.set(backstop_token, bid_amount);
 
@@ -858,7 +858,7 @@ mod tests {
                 100,
             );
             assert_eq!(result.block, 51);
-            assert_eq!(result.bid.get_unchecked(backstop_token_id), 336_0000000);
+            assert_eq!(result.bid.get_unchecked(backstop_token_id), 288_0000000);
             assert_eq!(result.bid.len(), 1);
             assert_eq!(result.lot.get_unchecked(underlying_0), 100_0000000);
             assert_eq!(result.lot.get_unchecked(underlying_1), 25_0000000);
@@ -976,7 +976,7 @@ mod tests {
                 100,
             );
             assert_eq!(result.block, 51);
-            assert_eq!(result.bid.get_unchecked(backstop_token_id), 336_0000000);
+            assert_eq!(result.bid.get_unchecked(backstop_token_id), 288_0000000);
             assert_eq!(result.bid.len(), 1);
             assert_eq!(result.lot.get_unchecked(underlying_0), 100_0000000);
             assert_eq!(result.lot.get_unchecked(underlying_1), 25_0000000);
@@ -1094,7 +1094,7 @@ mod tests {
                 100,
             );
             assert_eq!(result.block, 151);
-            assert_eq!(result.bid.get_unchecked(backstop_token_id), 336_0010346);
+            assert_eq!(result.bid.get_unchecked(backstop_token_id), 288_0008868);
             assert_eq!(result.bid.len(), 1);
             assert_eq!(result.lot.get_unchecked(underlying_0), 100_0000713);
             assert_eq!(result.lot.get_unchecked(underlying_1), 25_0000178);

--- a/pool/src/auctions/bad_debt_auction.rs
+++ b/pool/src/auctions/bad_debt_auction.rs
@@ -110,11 +110,13 @@ pub fn fill_bad_debt_auction(
     let backstop_client = BackstopClient::new(e, &backstop_address);
     let backstop_token_id = backstop_client.backstop_token();
     let lot_amount = auction_data.lot.get(backstop_token_id).unwrap_or(0);
-    backstop_client.draw(
-        &e.current_contract_address(),
-        &lot_amount,
-        &filler_state.address,
-    );
+    if lot_amount > 0 {
+        backstop_client.draw(
+            &e.current_contract_address(),
+            &lot_amount,
+            &filler_state.address,
+        );
+    }
 
     // If the backstop still has liabilities and less than 5% of the backstop threshold burn bad debt
     if !backstop_state.positions.liabilities.is_empty() {

--- a/pool/src/auctions/bad_debt_auction.rs
+++ b/pool/src/auctions/bad_debt_auction.rs
@@ -83,7 +83,7 @@ pub fn create_bad_debt_auction_data(
     // determine lot amount of backstop tokens needed to safely cover bad debt, or post
     // all backstop tokens if there isn't enough to cover the bad debt
     let mut lot_amount = debt_value
-        .fixed_mul_floor(e, &1_4000000, &SCALAR_7)
+        .fixed_mul_floor(e, &1_2000000, &SCALAR_7)
         .fixed_div_floor(e, &backstop_token_to_base, &SCALAR_7);
     lot_amount = pool_backstop_data.tokens.min(lot_amount);
     auction_data.lot.set(backstop_token, lot_amount);
@@ -987,7 +987,7 @@ mod tests {
             assert_eq!(result.bid.get_unchecked(underlying_0), 10_0000000);
             assert_eq!(result.bid.get_unchecked(underlying_1), 2_5000000);
             assert_eq!(result.bid.len(), 2);
-            assert_eq!(result.lot.get_unchecked(lp_token), 38_0800000);
+            assert_eq!(result.lot.get_unchecked(lp_token), 32_6400000);
             assert_eq!(result.lot.len(), 1);
         });
     }
@@ -1126,7 +1126,7 @@ mod tests {
             assert_eq!(result.bid.get_unchecked(underlying_0), 10_0000000);
             assert_eq!(result.bid.get_unchecked(underlying_1), 2_5000000);
             assert_eq!(result.bid.len(), 2);
-            assert_eq!(result.lot.get_unchecked(lp_token), 38_0800000);
+            assert_eq!(result.lot.get_unchecked(lp_token), 32_6400000);
             assert_eq!(result.lot.len(), 1);
         });
     }
@@ -1158,7 +1158,7 @@ mod tests {
             testutils::create_comet_lp_pool(&e, &bombadil, &blnd, &usdc);
         let (backstop_address, backstop_client) =
             testutils::create_backstop(&e, &pool_address, &lp_token, &usdc, &blnd);
-        // mint lp tokens - only deposit 38_0000000
+        // mint lp tokens - only deposit 32_0000000
         blnd_client.mint(&samwise, &500_001_0000000);
         blnd_client.approve(&samwise, &lp_token, &i128::MAX, &99999);
         usdc_client.mint(&samwise, &12_501_0000000);
@@ -1168,7 +1168,7 @@ mod tests {
             &vec![&e, 500_001_0000000, 12_501_0000000],
             &samwise,
         );
-        backstop_client.deposit(&samwise, &pool_address, &38_0000000);
+        backstop_client.deposit(&samwise, &pool_address, &32_0000000);
         backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
@@ -1260,7 +1260,7 @@ mod tests {
             assert_eq!(result.bid.get_unchecked(underlying_0), 10_0000000);
             assert_eq!(result.bid.get_unchecked(underlying_1), 2_5000000);
             assert_eq!(result.bid.len(), 2);
-            assert_eq!(result.lot.get_unchecked(lp_token), 38_0000000);
+            assert_eq!(result.lot.get_unchecked(lp_token), 32_0000000);
             assert_eq!(result.lot.len(), 1);
         });
     }
@@ -1394,7 +1394,7 @@ mod tests {
             assert_eq!(result.bid.get_unchecked(underlying_0), 10_0000000);
             assert_eq!(result.bid.get_unchecked(underlying_1), 2_5000000);
             assert_eq!(result.bid.len(), 2);
-            assert_eq!(result.lot.get_unchecked(lp_token), 38_0801894);
+            assert_eq!(result.lot.get_unchecked(lp_token), 32_6401624);
             assert_eq!(result.lot.len(), 1);
         });
     }
@@ -1526,7 +1526,7 @@ mod tests {
             assert_eq!(result.block, 51);
             assert_eq!(result.bid.get_unchecked(underlying_0), 10_0000000);
             assert_eq!(result.bid.len(), 1);
-            assert_eq!(result.lot.get_unchecked(lp_token), 24_6400000);
+            assert_eq!(result.lot.get_unchecked(lp_token), 21_1200000);
             assert_eq!(result.lot.len(), 1);
         });
     }

--- a/pool/src/auctions/bad_debt_auction.rs
+++ b/pool/src/auctions/bad_debt_auction.rs
@@ -184,7 +184,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         e.ledger().set(LedgerInfo {
             timestamp: 12345,
@@ -249,7 +248,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         e.ledger().set(LedgerInfo {
             timestamp: 12345,
@@ -296,7 +294,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         e.ledger().set(LedgerInfo {
             timestamp: 12345,
@@ -372,7 +369,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -467,7 +463,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -575,7 +570,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -670,7 +664,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -765,7 +758,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -897,7 +889,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -1030,7 +1021,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -1169,7 +1159,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &32_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -1303,7 +1292,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -1437,7 +1425,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (oracle_id, oracle_client) = testutils::create_mock_oracle(&e);
 
@@ -1570,7 +1557,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();
@@ -1707,7 +1693,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &1_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();
@@ -1867,7 +1852,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &2_500_0000000);
-        backstop_client.update_tkn_val();
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();
@@ -2037,7 +2021,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();
@@ -2176,7 +2159,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_address, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();

--- a/pool/src/constants.rs
+++ b/pool/src/constants.rs
@@ -6,8 +6,11 @@ pub const SCALAR_12: i128 = 1_000_000_000_000;
 /// Fixed-point scalar for 7 decimal numbers
 pub const SCALAR_7: i128 = 1_0000000;
 
-// seconds per year
+/// Seconds per year
 pub const SECONDS_PER_YEAR: i128 = 31536000;
 
-// approximate week in blocks assuming 5 seconds per block
+/// Seconds per week
 pub const SECONDS_PER_WEEK: u64 = 604800;
+
+/// Max amount of reserves that can be added to a pool
+pub const MAX_RESERVES: u32 = 50;

--- a/pool/src/pool/actions.rs
+++ b/pool/src/pool/actions.rs
@@ -1492,7 +1492,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&bombadil, &pool_address, &(50 * SCALAR_7));
-        backstop_client.update_tkn_val();
 
         let (underlying_0, underlying_0_client) = testutils::create_token_contract(&e, &bombadil);
         let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();

--- a/pool/src/pool/status.rs
+++ b/pool/src/pool/status.rs
@@ -184,7 +184,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -231,7 +230,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &20_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -275,7 +273,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &30_000_0000000);
 
         let pool_config = PoolConfig {
@@ -318,7 +315,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -365,7 +361,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &40_000_0000000);
 
         let pool_config = PoolConfig {
@@ -409,7 +404,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &40_000_0000000);
 
         let pool_config = PoolConfig {
@@ -452,7 +446,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -498,7 +491,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -541,7 +533,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -588,7 +579,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -635,7 +625,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &20_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -682,7 +671,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &15_000_0000000);
 
         let pool_config = PoolConfig {
@@ -730,7 +718,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &15_000_0000000);
 
         let pool_config = PoolConfig {
@@ -778,7 +765,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &25_000_0000000);
 
         let pool_config = PoolConfig {
@@ -826,7 +812,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &30_000_0000000);
 
         let pool_config = PoolConfig {
@@ -873,7 +858,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &30_000_0000000);
 
         let pool_config = PoolConfig {
@@ -921,7 +905,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &40_000_0000000);
 
         let pool_config = PoolConfig {
@@ -970,7 +953,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -1014,7 +996,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
 
         let pool_config = PoolConfig {
             oracle: oracle_id,
@@ -1058,7 +1039,6 @@ mod tests {
             &samwise,
         );
         backstop_client.deposit(&samwise, &pool_id, &50_000_0000000);
-        backstop_client.update_tkn_val();
         backstop_client.queue_withdrawal(&samwise, &pool_id, &12_500_0000000);
 
         let pool_config = PoolConfig {

--- a/pool/src/pool/user.rs
+++ b/pool/src/pool/user.rs
@@ -196,7 +196,7 @@ impl User {
         self.get_collateral(reserve_index) + self.get_supply(reserve_index)
     }
 
-    // Removes positions from a user - does not consider supply
+    /// Removes positions from a user - does not consider supply
     pub fn rm_positions(
         &mut self,
         e: &Env,
@@ -205,18 +205,22 @@ impl User {
         liability_amounts: Map<Address, i128>,
     ) {
         for (asset, amount) in collateral_amounts.iter() {
-            let mut reserve = pool.load_reserve(e, &asset, true);
-            self.remove_collateral(e, &mut reserve, amount);
-            pool.cache_reserve(reserve);
+            if amount > 0 {
+                let mut reserve = pool.load_reserve(e, &asset, true);
+                self.remove_collateral(e, &mut reserve, amount);
+                pool.cache_reserve(reserve);
+            }
         }
         for (asset, amount) in liability_amounts.iter() {
-            let mut reserve = pool.load_reserve(e, &asset, true);
-            self.remove_liabilities(e, &mut reserve, amount);
-            pool.cache_reserve(reserve);
+            if amount > 0 {
+                let mut reserve = pool.load_reserve(e, &asset, true);
+                self.remove_liabilities(e, &mut reserve, amount);
+                pool.cache_reserve(reserve);
+            }
         }
     }
 
-    // Adds positions to a user - does not consider supply
+    /// Adds positions to a user - does not consider supply
     pub fn add_positions(
         &mut self,
         e: &Env,
@@ -225,14 +229,18 @@ impl User {
         liability_amounts: Map<Address, i128>,
     ) {
         for (asset, amount) in collateral_amounts.iter() {
-            let mut reserve = pool.load_reserve(e, &asset, true);
-            self.add_collateral(e, &mut reserve, amount);
-            pool.cache_reserve(reserve);
+            if amount > 0 {
+                let mut reserve = pool.load_reserve(e, &asset, true);
+                self.add_collateral(e, &mut reserve, amount);
+                pool.cache_reserve(reserve);
+            }
         }
         for (asset, amount) in liability_amounts.iter() {
-            let mut reserve = pool.load_reserve(e, &asset, true);
-            self.add_liabilities(e, &mut reserve, amount);
-            pool.cache_reserve(reserve);
+            if amount > 0 {
+                let mut reserve = pool.load_reserve(e, &asset, true);
+                self.add_liabilities(e, &mut reserve, amount);
+                pool.cache_reserve(reserve);
+            }
         }
     }
 

--- a/pool/src/storage.rs
+++ b/pool/src/storage.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{
     String, Symbol, TryFromVal, Val, Vec,
 };
 
-use crate::{auctions::AuctionData, pool::Positions, PoolError};
+use crate::{auctions::AuctionData, constants::MAX_RESERVES, pool::Positions, PoolError};
 
 /********** Ledger Thresholds **********/
 
@@ -54,7 +54,7 @@ pub struct ReserveConfig {
     pub r_three: u32, // the R3 value in the interest rate formula scaled expressed in 7 decimals
     pub reactivity: u32, // the reactivity constant for the reserve scaled expressed in 7 decimals
     pub collateral_cap: i128, // the total amount of underlying tokens that can be used as collateral
-    pub enabled: bool,        // the flag of the reserve
+    pub enabled: bool,        // the enabled flag of the reserve
 }
 
 #[derive(Clone)]
@@ -447,12 +447,12 @@ pub fn get_res_list(e: &Env) -> Vec<Address> {
 /// * `asset` - The contract address of the underlying asset
 ///
 /// ### Panics
-/// If the number of reserves in the list exceeds 32
+/// If the number of reserves in the list exceeds 50
 ///
 // @dev: Once added it can't be removed
 pub fn push_res_list(e: &Env, asset: &Address) -> u32 {
     let mut res_list = get_res_list(e);
-    if res_list.len() >= 32 {
+    if res_list.len() >= MAX_RESERVES {
         panic_with_error!(e, PoolError::BadRequest)
     }
     res_list.push_back(asset.clone());

--- a/test-suites/src/setup.rs
+++ b/test-suites/src/setup.rs
@@ -72,7 +72,6 @@ pub fn create_fixture_with_data<'a>(wasm: bool) -> TestFixture<'a> {
     fixture
         .backstop
         .deposit(&frodo, &pool_fixture.pool.address, &(50_000 * SCALAR_7));
-    // fixture.backstop.update_tkn_val();
     fixture
         .backstop
         .add_reward(&pool_fixture.pool.address, &None);

--- a/test-suites/src/setup.rs
+++ b/test-suites/src/setup.rs
@@ -72,7 +72,7 @@ pub fn create_fixture_with_data<'a>(wasm: bool) -> TestFixture<'a> {
     fixture
         .backstop
         .deposit(&frodo, &pool_fixture.pool.address, &(50_000 * SCALAR_7));
-    fixture.backstop.update_tkn_val();
+    // fixture.backstop.update_tkn_val();
     fixture
         .backstop
         .add_reward(&pool_fixture.pool.address, &None);

--- a/test-suites/tests/test_backstop_swap.rs
+++ b/test-suites/tests/test_backstop_swap.rs
@@ -461,7 +461,6 @@ fn deploy_v2_pool(
 
     // setup backstop and enable borrowing
     backstop_client.deposit(&creator, &pool_id, &(55_000 * SCALAR_7));
-    backstop_client.update_tkn_val();
     backstop_client.add_reward(&pool_id, &None);
     pool_client.set_status(&3);
     pool_client.update_status();

--- a/test-suites/tests/test_liquidation.rs
+++ b/test-suites/tests/test_liquidation.rs
@@ -47,7 +47,7 @@ fn assert_fill_auction_event_no_data(
 
 #[test]
 fn test_liquidations() {
-    let fixture = create_fixture_with_data(false);
+    let fixture = create_fixture_with_data(true);
     let frodo = fixture.users.get(0).unwrap();
     let pool_fixture = &fixture.pools[0];
 
@@ -198,6 +198,7 @@ fn test_liquidations() {
         ],
         &100u32,
     );
+
     let stable_interest_lot_amount = auction_data
         .lot
         .get_unchecked(fixture.tokens[TokenIndex::STABLE].address.clone());

--- a/test-suites/tests/test_liquidation.rs
+++ b/test-suites/tests/test_liquidation.rs
@@ -212,7 +212,7 @@ fn test_liquidations() {
     assert_approx_eq_abs(weth_interest_lot_amount, 0_002671545, 5000);
     let lp_donate_bid_amount = auction_data.bid.get_unchecked(fixture.lp.address.clone());
     //NOTE: bid STABLE amount is seven decimals whereas reserve(and lot) STABLE has 6 decomals
-    assert_approx_eq_abs(lp_donate_bid_amount, 313_7415968, SCALAR_7);
+    assert_approx_eq_abs(lp_donate_bid_amount, 268_9213686, SCALAR_7);
     assert_eq!(auction_data.block, 151);
     let liq_pct = 30;
     let events = fixture.env.events().all();
@@ -605,7 +605,7 @@ fn test_liquidations() {
         bad_debt_auction_data
             .lot
             .get_unchecked(fixture.lp.address.clone()),
-        7171_0435309, // lp_token value is $1.25 each
+        6146_6087407, // lp_token value is $1.25 each
         SCALAR_7,
     );
     let events = fixture.env.events().all();
@@ -678,12 +678,12 @@ fn test_liquidations() {
     );
     assert_approx_eq_abs(
         fixture.lp.balance(&frodo),
-        frodo_bstop_pre_fill + 717_1043530,
+        frodo_bstop_pre_fill + 614_6608740,
         SCALAR_7,
     );
     assert_approx_eq_abs(
         fixture.lp.balance(&fixture.backstop.address),
-        backstop_bstop_pre_fill - 717_1043531,
+        backstop_bstop_pre_fill - 614_6608740,
         SCALAR_7,
     );
     let new_auction = pool_fixture
@@ -718,7 +718,7 @@ fn test_liquidations() {
         bad_debt_auction_data
             .lot
             .get_unchecked(fixture.lp.address.clone())
-            - 1434_2087060,
+            - 1229_3217480,
         SCALAR_7,
     );
     assert_eq!(new_auction.block, bad_debt_auction_data.block);
@@ -763,12 +763,12 @@ fn test_liquidations() {
     );
     assert_approx_eq_abs(
         fixture.lp.balance(&frodo),
-        frodo_bstop_pre_fill + 4302_6261190,
+        frodo_bstop_pre_fill + 3687_9652440,
         SCALAR_7,
     );
     assert_approx_eq_abs(
         fixture.lp.balance(&fixture.backstop.address),
-        backstop_bstop_pre_fill - 4302_6261190,
+        backstop_bstop_pre_fill - 3687_9652440,
         SCALAR_7,
     );
 
@@ -785,7 +785,7 @@ fn test_liquidations() {
         .withdraw(&frodo, &pool_fixture.pool.address, &original_deposit);
     assert_approx_eq_abs(
         fixture.lp.balance(&frodo) - pre_withdraw_frodo_bstp,
-        original_deposit - 717_1043530 - 4302_6261190 + 313_7415968,
+        original_deposit - 614_6608740 - 3687_9652440 + 268_9213686,
         SCALAR_7,
     );
     fixture

--- a/test-suites/tests/test_pool_inflation_attack.rs
+++ b/test-suites/tests/test_pool_inflation_attack.rs
@@ -32,7 +32,6 @@ fn test_pool_inflation_attack() {
     fixture
         .backstop
         .deposit(&whale, &fixture.pools[0].pool.address, &(50_000 * SCALAR_7));
-    // fixture.backstop.update_tkn_val();
     fixture.pools[0].pool.set_status(&0);
     fixture.jump_with_sequence(60);
 

--- a/test-suites/tests/test_pool_inflation_attack.rs
+++ b/test-suites/tests/test_pool_inflation_attack.rs
@@ -32,7 +32,7 @@ fn test_pool_inflation_attack() {
     fixture
         .backstop
         .deposit(&whale, &fixture.pools[0].pool.address, &(50_000 * SCALAR_7));
-    fixture.backstop.update_tkn_val();
+    // fixture.backstop.update_tkn_val();
     fixture.pools[0].pool.set_status(&0);
     fixture.jump_with_sequence(60);
 


### PR DESCRIPTION
* don't attempt to donate or draw 0 token values during 400+ block bad debt or interest auctions
* don't rm or add 0 value positions during liquidations
* lower bad debt and interest backstop token inflation value to 20% instead of 40%
* calculate backstop token value on demand when loading backstop_pool_data, remove `update_token_val`